### PR TITLE
FilterTool: rework to use transfer functions directly

### DIFF
--- a/FilterTool/index.html
+++ b/FilterTool/index.html
@@ -8,7 +8,7 @@
 <script type="text/javascript" src={{url_for('static', filename='filters.js')}}></script>
 <script type="text/javascript" src={{url_for('static', filename='FileSaver.js')}}></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.js"></script>
-<script src="https://www.lactame.com/lib/ml/6.0.0/ml.min.js"></script>
+<script src="https://unpkg.com/mathjs/lib/browser/math.js"></script>
 </head>
 <a href="https://ardupilot.org"><img src="../images/ArduPilot.png"></a>
 <h1>ArduPilot Filter Analysis</h1>


### PR DESCRIPTION
This moves from "brute forcing" the transfer function to using them directly as checked with https://github.com/ArduPilot/ardupilot/pull/23839