### PR TITLE
FilterReview: add post filter estimate and bode plots 

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -75,12 +75,29 @@
                 </fieldset>
             </td>
             <td>
+                <fieldset style="width:100px;height:80px">
+                    <legend>Log type</legend>
+                    <input type="radio" id="log_type_batch" name="log_type" checked>
+                    <label for="log_type_batch">Batch</label><br>
+                    <input type="radio" id="log_type_raw" name="log_type">
+                    <label for="log_type_raw">Raw sensor</label><br>
+                </fieldset>
+            </td>
+            <td>
                 <fieldset style="width:200px;height:80px">
                     <legend>FFT Settings</legend>
-                    <label for="FFTWindow">Windows per batch</label>
-                    <input id="FFTWindow" name="FFTWindow" type="number" min="1" step="1" value="1" onchange="clear_calculation()" style="width:50px"/>
-                    <br><br>
-                    <label id="FFTWindowInfo"></label>
+                    <table>
+                        <tr>
+                            <td style="width: 125px;">
+                                <label for="FFTWindow_per_batch">Windows per batch</label><br><br>
+                                <label for="FFTWindow_size">Windows size</label>
+                            </td>
+                            <td>
+                                <input id="FFTWindow_per_batch" name="FFTWindow_per_batch" type="number" min="1" step="1" value="1" onchange="clear_calculation()" style="width:50px"/><br><br>
+                                <input id="FFTWindow_size" name="FFTWindow_size" type="number" min="1" step="1" value="1024" onchange="clear_calculation()" style="width:50px"/>
+                            </td>
+                        </tr>
+                    </table>
                 </fieldset>
             </td>
             <td>

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -36,21 +36,14 @@
     <table>
         <tr>
             <td>
-                <fieldset style="width:150px;height:80px">
+                <fieldset style="width:180px;height:80px">
                     <legend>Amplitude scale</legend>
-                    <input type="radio" id="ScaleLog" name="Scale" checked>
-                    <label for="LogScale">dB</label><br>
                     <input type="radio" id="ScaleLinear" name="Scale">
-                    <label for="LinearScale">Linear</label><br>
-                </fieldset>
-            </td>
-            <td>
-                <fieldset style="width:200px;height:80px">
-                    <legend>Spectrum scale</legend>
-                    <input type="radio" id="SpectrumLinear" name="SpectrumScale" checked>
-                    <label for="SpectrumLinear">Linear</label><br>
-                    <input type="radio" id="SpectrumPSD" name="SpectrumScale">
-                    <label for="SpectrumPSD">Power Spectral Density</label><br>
+                    <label for="ScaleLinear">Linear</label><br>
+                    <input type="radio" id="ScaleLog" name="Scale" checked>
+                    <label for="ScaleLog">dB</label><br>
+                    <input type="radio" id="ScalePSD" name="Scale">
+                    <label for="ScalePSD">Power Spectral Density</label><br>
                 </fieldset>
             </td>
             <td>

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -262,6 +262,13 @@
     </tr>
 </table>
 
+<p>
+    <div id="BodeAmp" style="width:1200px;height:450px"></div>
+</p>
+<p>
+    <div id="BodePhase" style="width:1200px;height:450px"></div>
+</p>
+
 <table>
 <tr>
 <td style="width: 60px;"></td>
@@ -270,49 +277,49 @@
     <legend>Gyro filter</legend>
     <p>
         <label class="parameter_input_label" for="INS_GYRO_FILTER">INS_GYRO_FILTER</label>
-        <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+        <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" onchange="filter_param_change();" style="width: 100px"/>
     </p>
 </fieldset>
 <fieldset style="width:1070px">
     <legend>First Notch Filter</legend>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
-        <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+        <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px"/>
         <label id="INS_HNTCH_ENABLE.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_MODE">INS_HNTCH_MODE</label>
-        <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTCH_MODE.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_FREQ">INS_HNTCH_FREQ</label>
-        <input id="INS_HNTCH_FREQ" name="INS_HNTCH_FREQ" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_FREQ" name="INS_HNTCH_FREQ" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_BW">INS_HNTCH_BW</label>
-        <input id="INS_HNTCH_BW" name="INS_HNTCH_BW" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_BW" name="INS_HNTCH_BW" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_ATT">INS_HNTCH_ATT</label>
-        <input id="INS_HNTCH_ATT" name="INS_HNTCH_ATT" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_ATT" name="INS_HNTCH_ATT" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_REF">INS_HNTCH_REF</label>
-        <input id="INS_HNTCH_REF" name="INS_HNTCH_REF" type="number" step="0.01" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_REF" name="INS_HNTCH_REF" type="number" step="0.01" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_FM_RAT">INS_HNTCH_FM_RAT</label>
-        <input id="INS_HNTCH_FM_RAT" name="INS_HNTCH_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_FM_RAT" name="INS_HNTCH_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_HMNCS">INS_HNTCH_HMNCS</label>
-        <input id="INS_HNTCH_HMNCS" name="INS_HNTCH_HMNCS" type="number" step="1" value="1" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_HMNCS" name="INS_HNTCH_HMNCS" type="number" step="1" value="1" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTCH_HMNCS.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTCH_OPTS">INS_HNTCH_OPTS</label>
-        <input id="INS_HNTCH_OPTS" name="INS_HNTCH_OPTS" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTCH_OPTS" name="INS_HNTCH_OPTS" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTCH_OPTS.doc"></label>
     </p>
 </fieldset>
@@ -320,42 +327,42 @@
     <legend>Second Notch Filter</legend>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_ENABLE">INS_HNTC2_ENABLE</label>
-        <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+        <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px"/>
         <label id="INS_HNTC2_ENABLE.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_MODE">INS_HNTC2_MODE</label>
-        <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTC2_MODE.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_FREQ">INS_HNTC2_FREQ</label>
-        <input id="INS_HNTC2_FREQ" name="INS_HNTC2_FREQ" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_FREQ" name="INS_HNTC2_FREQ" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_BW">INS_HNTC2_BW</label>
-        <input id="INS_HNTC2_BW" name="INS_HNTC2_BW" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_BW" name="INS_HNTC2_BW" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_ATT">INS_HNTC2_ATT</label>
-        <input id="INS_HNTC2_ATT" name="INS_HNTC2_ATT" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_ATT" name="INS_HNTC2_ATT" type="number" step="0.1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_REF">INS_HNTC2_REF</label>
-        <input id="INS_HNTC2_REF" name="INS_HNTC2_REF" type="number" step="0.01" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_REF" name="INS_HNTC2_REF" type="number" step="0.01" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_FM_RAT">INS_HNTC2_FM_RAT</label>
-        <input id="INS_HNTC2_FM_RAT" name="INS_HNTC2_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_FM_RAT" name="INS_HNTC2_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_change();" style="width: 100px" disabled/>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_HMNCS">INS_HNTC2_HMNCS</label>
-        <input id="INS_HNTC2_HMNCS" name="INS_HNTC2_HMNCS" type="number" step="1" value="1" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_HMNCS" name="INS_HNTC2_HMNCS" type="number" step="1" value="1" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTC2_HMNCS.doc"></label>
     </p>
     <p>
         <label class="parameter_input_label" for="INS_HNTC2_OPTS">INS_HNTC2_OPTS</label>
-        <input id="INS_HNTC2_OPTS" name="INS_HNTC2_OPTS" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <input id="INS_HNTC2_OPTS" name="INS_HNTC2_OPTS" type="number" step="1" value="0" onchange="filter_param_change();" style="width: 100px" disabled/>
         <label id="INS_HNTC2_OPTS.doc"></label>
     </p>
 </fieldset>
@@ -371,10 +378,10 @@
     <tr>
         <td style="width: 60px;"></td>
         <td>
-            <fieldset style="width:300px;height:350px">
+            <fieldset style="width:350px;height:350px">
                 <legend>Spectrogram Options</legend>
                 <p>
-                    <fieldset style="width:300px">
+                    <fieldset style="width:350px">
                         <legend>Gyro instance</legend>
                         <input type="radio" id="SpecGyroInst0" name="SpecGyroInst" onchange="redraw_Spectrogram()" disabled>
                         <label for="SpecGyroInst0">1</label>
@@ -387,17 +394,20 @@
                     </fieldset>
                 </p>
                 <p>
-                    <fieldset style="width:300px">
+                    <fieldset style="width:350px">
                         <legend>Filtering</legend>
                         <input type="radio" id="SpecGyroPre" name="SpecGyroPrePost" onchange="redraw_Spectrogram()" disabled>
                         <label for="SpecGyroPre">Pre-filter</label>
 
                         <input type="radio" id="SpecGyroPost" name="SpecGyroPrePost" onchange="redraw_Spectrogram()" disabled>
                         <label for="SpecGyroPost">Post-filter</label>
+
+                        <input type="radio" id="SpecGyroEstPost" name="SpecGyroPrePost" onchange="redraw_Spectrogram()" disabled>
+                        <label for="SpecGyroEstPost">Estimated post-filter</label>
                     </fieldset>
                 </p>
                 <p>
-                    <fieldset style="width:300px">
+                    <fieldset style="width:350px">
                         <legend>Axis</legend>
                         <input type="radio" id="SpecGyroAxisX" name="SpecGyroAxis" onchange="redraw_Spectrogram()" disabled>
                         <label for="SpecGyroAxisX">X</label>

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -23,7 +23,6 @@
     label.parameter_input_label {
         display: inline-block;
         width: 160px;
-        text-align: right;
         margin:5px 0px;
     }
 </style>
@@ -142,6 +141,19 @@
                         <label for="Gyro0PostZ">Z</label>
                     </fieldset>
                 </p>
+                <p>
+                    <fieldset style="width:300px">
+                        <legend>Estimated post-filter</legend>
+                        <input type="checkbox" id="Gyro0PostEstX" name="Gyro0PostEstX" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro0PostEstX">X</label>
+
+                        <input type="checkbox" id="Gyro0PostEstY" name="Gyro0PostEstY" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro0PostEstY">Y</label>
+
+                        <input type="checkbox" id="Gyro0PostEstZ" name="Gyro0PostEstZ" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro0PostEstZ">Z</label>
+                    </fieldset>
+                </p>
                 <label id="Gyro0_FFT_info"><br><br><br></label>
              </fieldset>
         </td>
@@ -173,6 +185,19 @@
 
                         <input type="checkbox" id="Gyro1PostZ" name="Gyro1PostZ" onchange="update_hidden(this)" checked disabled>
                         <label for="Gyro1PostZ">Z</label>
+                    </fieldset>
+                </p>
+                <p>
+                    <fieldset style="width:300px">
+                        <legend>Estimated post-filter</legend>
+                        <input type="checkbox" id="Gyro1PostEstX" name="Gyro1PostEstX" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro1PostEstX">X</label>
+
+                        <input type="checkbox" id="Gyro1PostEstY" name="Gyro1PostEstY" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro1PostEstY">Y</label>
+
+                        <input type="checkbox" id="Gyro1PostEstZ" name="Gyro1PostEstZ" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro1PostEstZ">Z</label>
                     </fieldset>
                 </p>
                 <label id="Gyro1_FFT_info"><br><br><br></label>
@@ -208,12 +233,125 @@
                         <label for="Gyro2PostZ">Z</label>
                     </fieldset>
                 </p>
+                <p>
+                    <fieldset style="width:300px">
+                        <legend>Estimated post-filter</legend>
+                        <input type="checkbox" id="Gyro2PostEstX" name="Gyro2PostEstX" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro2PostEstX">X</label>
+    
+                        <input type="checkbox" id="Gyro2PostEstY" name="Gyro2PostEstY" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro2PostEstY">Y</label>
+    
+                        <input type="checkbox" id="Gyro2PostEstZ" name="Gyro2PostEstZ" onchange="update_hidden(this)" disabled>
+                        <label for="Gyro2PostEstZ">Z</label>
+                    </fieldset>
+                </p>
                 <label id="Gyro2_FFT_info"><br><br><br></label>
             </fieldset>
         </td>
     </tr>
 </table>
 
+<table>
+<tr>
+<td style="width: 60px;"></td>
+<td>
+<fieldset style="width:1070px">
+    <legend>Gyro filter</legend>
+    <p>
+        <label class="parameter_input_label" for="INS_GYRO_FILTER">INS_GYRO_FILTER</label>
+        <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+    </p>
+</fieldset>
+<fieldset style="width:1070px">
+    <legend>First Notch Filter</legend>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
+        <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+        <label id="INS_HNTCH_ENABLE.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_MODE">INS_HNTCH_MODE</label>
+        <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTCH_MODE.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_FREQ">INS_HNTCH_FREQ</label>
+        <input id="INS_HNTCH_FREQ" name="INS_HNTCH_FREQ" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_BW">INS_HNTCH_BW</label>
+        <input id="INS_HNTCH_BW" name="INS_HNTCH_BW" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_ATT">INS_HNTCH_ATT</label>
+        <input id="INS_HNTCH_ATT" name="INS_HNTCH_ATT" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_REF">INS_HNTCH_REF</label>
+        <input id="INS_HNTCH_REF" name="INS_HNTCH_REF" type="number" step="0.01" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_FM_RAT">INS_HNTCH_FM_RAT</label>
+        <input id="INS_HNTCH_FM_RAT" name="INS_HNTCH_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_HMNCS">INS_HNTCH_HMNCS</label>
+        <input id="INS_HNTCH_HMNCS" name="INS_HNTCH_HMNCS" type="number" step="1" value="1" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTCH_HMNCS.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTCH_OPTS">INS_HNTCH_OPTS</label>
+        <input id="INS_HNTCH_OPTS" name="INS_HNTCH_OPTS" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTCH_OPTS.doc"></label>
+    </p>
+</fieldset>
+<fieldset style="width:1070px">
+    <legend>Second Notch Filter</legend>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_ENABLE">INS_HNTC2_ENABLE</label>
+        <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px"/>
+        <label id="INS_HNTC2_ENABLE.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_MODE">INS_HNTC2_MODE</label>
+        <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTC2_MODE.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_FREQ">INS_HNTC2_FREQ</label>
+        <input id="INS_HNTC2_FREQ" name="INS_HNTC2_FREQ" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_BW">INS_HNTC2_BW</label>
+        <input id="INS_HNTC2_BW" name="INS_HNTC2_BW" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_ATT">INS_HNTC2_ATT</label>
+        <input id="INS_HNTC2_ATT" name="INS_HNTC2_ATT" type="number" step="0.1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_REF">INS_HNTC2_REF</label>
+        <input id="INS_HNTC2_REF" name="INS_HNTC2_REF" type="number" step="0.01" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_FM_RAT">INS_HNTC2_FM_RAT</label>
+        <input id="INS_HNTC2_FM_RAT" name="INS_HNTC2_FM_RAT" type="number" step="0.01" value="1.0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_HMNCS">INS_HNTC2_HMNCS</label>
+        <input id="INS_HNTC2_HMNCS" name="INS_HNTC2_HMNCS" type="number" step="1" value="1" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTC2_HMNCS.doc"></label>
+    </p>
+    <p>
+        <label class="parameter_input_label" for="INS_HNTC2_OPTS">INS_HNTC2_OPTS</label>
+        <input id="INS_HNTC2_OPTS" name="INS_HNTC2_OPTS" type="number" step="1" value="0" onchange="filter_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
+        <label id="INS_HNTC2_OPTS.doc"></label>
+    </p>
+</fieldset>
+</td>
+</tr>
+</table>
 
 <p>
     <div id="Spectrogram" style="width:1200px;height:450px"></div>
@@ -261,72 +399,6 @@
                         <label for="SpecGyroAxisZ">Z</label>
                     </fieldset>
                 </p>
-            </fieldset>
-        </td>
-        <td>
-            <fieldset style="width:300px;height:350px">
-                <legend>First Notch Filter</legend>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_ENABLE">INS_HNTCH_ENABLE</label>
-                        <input id="INS_HNTCH_ENABLE" name="INS_HNTCH_ENABLE" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_MODE">INS_HNTCH_MODE</label>
-                        <input id="INS_HNTCH_MODE" name="INS_HNTCH_MODE" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_FREQ">INS_HNTCH_FREQ</label>
-                        <input id="INS_HNTCH_FREQ" name="INS_HNTCH_FREQ" type="number" step="0.1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_REF">INS_HNTCH_REF</label>
-                        <input id="INS_HNTCH_REF" name="INS_HNTCH_REF" type="number" step="0.01" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                   </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_FM_RAT">INS_HNTCH_FM_RAT</label>
-                        <input id="INS_HNTCH_FM_RAT" name="INS_HNTCH_FM_RAT" type="number" step="0.01" value="1.0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                   </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_HMNCS">INS_HNTCH_HMNCS</label>
-                        <input id="INS_HNTCH_HMNCS" name="INS_HNTCH_HMNCS" type="number" step="1" value="1" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTCH_OPTS">INS_HNTCH_OPTS</label>
-                        <input id="INS_HNTCH_OPTS" name="INS_HNTCH_OPTS" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-            </fieldset>
-        </td>
-        <td>
-            <fieldset style="width:300px;height:350px">
-                <legend>Second Notch Filter</legend>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_ENABLE">INS_HNTC2_ENABLE</label>
-                        <input id="INS_HNTC2_ENABLE" name="INS_HNTC2_ENABLE" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_MODE">INS_HNTC2_MODE</label>
-                        <input id="INS_HNTC2_MODE" name="INS_HNTC2_MODE" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_FREQ">INS_HNTC2_FREQ</label>
-                        <input id="INS_HNTC2_FREQ" name="INS_HNTC2_FREQ" type="number" step="0.1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_REF">INS_HNTC2_REF</label>
-                        <input id="INS_HNTC2_REF" name="INS_HNTC2_REF" type="number" step="0.01" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                   </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_FM_RAT">INS_HNTC2_FM_RAT</label>
-                        <input id="INS_HNTC2_FM_RAT" name="INS_HNTC2_FM_RAT" type="number" step="0.01" value="1.0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                   </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_HMNCS">INS_HNTC2_HMNCS</label>
-                        <input id="INS_HNTC2_HMNCS" name="INS_HNTC2_HMNCS" type="number" step="1" value="1" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
-                    <p>
-                        <label class="parameter_input_label" for="INS_HNTC2_OPTS">INS_HNTC2_OPTS</label>
-                        <input id="INS_HNTC2_OPTS" name="INS_HNTC2_OPTS" type="number" step="1" value="0" onchange="HNotch_param_read(); redraw_Spectrogram();" style="width: 100px" disabled/>
-                    </p>
             </fieldset>
         </td>
     </tr>


### PR DESCRIPTION
Post filter estimate from pre-filter data and filter configuration:

![image](https://github.com/ArduPilot/WebTools/assets/33176108/dd059771-0047-431e-863d-1130025626e2)

Bode plots:
![image](https://github.com/ArduPilot/WebTools/assets/33176108/53a84355-25f7-47df-a674-47cb036b5d1c)

This does make it all quite slow again, the filter evaluation takes ages, certainly a fair bit of scope for speeding it up. I would also like to use a smaller frequency step on the bode plots (more like filter tool), currently they match the FFT's because that is what we need to estimate post filter. But that would make it extremely slow. The big frequency steps also mean that the phase unwrap can come out wrong since we can get correct changes of more than 180 deg.