### PR TITLE
FilterReview: more speed and less memory, also add a new re-calc button

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -955,6 +955,7 @@ function reset() {
     document.getElementById("TimeStart").disabled = true
     document.getElementById("TimeEnd").disabled = true
     document.getElementById("calculate").disabled = true
+    document.getElementById("calculate_filters").disabled = true
 
     // Disable all plot selection checkboxes
     for (let i = 0; i < 3; i++) {
@@ -1523,6 +1524,8 @@ function calculate_transfer_function() {
         }
     }
 
+    // Just updated, disable calc button
+    document.getElementById("calculate_filters").disabled = true
 }
 
 
@@ -2307,7 +2310,7 @@ function filter_param_read() {
         }
     }
 
-    document.getElementById('calculate').disabled = false
+    document.getElementById('calculate_filters').disabled = false
 
 }
 
@@ -2320,6 +2323,7 @@ function time_range_changed() {
     Plotly.redraw("FlightData")
 
     document.getElementById('calculate').disabled = false
+    document.getElementById('calculate_filters').disabled = false
 }
 
 // Load from batch logging messages

--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -24,9 +24,10 @@ class NotchTarget {
         }
 
         // Grab all given keys to data struct
-        this.data.time = []
-        this.data.value = []
-        for (var i=0; i < log.messages[msg_name].time_boot_ms.length; i++) {
+        const len = log.messages[msg_name].time_boot_ms.length
+        this.data.time = new Array(len)
+        this.data.value = new Array(len)
+        for (var i=0; i < len; i++) {
             this.data.time[i] = log.messages[msg_name].time_boot_ms[i] / 1000
             this.data.value[i] = log.messages[msg_name][key_name][i]
         }
@@ -84,9 +85,10 @@ class NotchTarget {
         if (config.ref == 0) {
             return { freq:[config.freq, config.freq], time:[this.data.time[0], this.data.time[this.data.time.length]] }
         }
-        var freq = []
-        for (let j=0;j<this.data.value.length;j++) {
-            freq.push(this.get_target_freq_index(config, j))
+        const len = this.data.value.length
+        var freq = new Array(len)
+        for (let j=0;j<len;j++) {
+            freq[j] = this.get_target_freq_index(config, j)
         }
         return { freq:freq, time:this.data.time }
     }
@@ -252,8 +254,9 @@ class ESCTarget extends NotchTarget {
 
         const dynamic = (config.options & (1<<1)) != 0
         if (dynamic) {
-            let ret = []
-            for (var j=0; j < this.data.length; j++) {
+            const len = this.data.length
+            let ret = new Array(len)
+            for (var j=0; j < len; j++) {
                 ret[j] = this.get_target(config, this.data.interpolated[instance][j][index])
             }
             return ret
@@ -274,17 +277,18 @@ class ESCTarget extends NotchTarget {
         const dynamic = (config.options & (1<<1)) != 0
         if (dynamic) {
             // Tracking individual motor RPM's
-            let freq = []
-            let time = []
+            const len = this.data.length
+            let freq = new Array(len)
+            let time = new Array(len)
 
-            for (let i = 0; i < this.data.length; i++) {
+            for (let i = 0; i < len; i++) {
                 let inst_freq = this.data[i].freq
                 for (let j = 0; j < inst_freq.length; j++) {
                     inst_freq[j] = this.get_target(config, inst_freq[j])
                 }
 
-                time.push(this.data[i].time)
-                freq.push(inst_freq)
+                time[i] = this.data[i].time
+                freq[i] = inst_freq
             }
             return { freq:freq, time:time }
 
@@ -360,8 +364,9 @@ class FFTTarget extends NotchTarget {
 
         const dynamic = (config.options & (1<<1)) != 0
         if (dynamic) {
-            let ret = []
-            for (var j=0; j < this.data.length; j++) {
+            const len = this.data.length
+            let ret = new Array(len)
+            for (var j=0; j < len; j++) {
                 ret[j] = this.get_target(config, this.data.interpolated[instance][j][index])
             }
             return ret
@@ -378,17 +383,18 @@ class FFTTarget extends NotchTarget {
         const dynamic = (config.options & (1<<1)) != 0
         if (dynamic) {
             // Tracking multiple peaks
-            let freq = []
-            let time = []
+            const len = this.data.length
+            let freq = new Array(len)
+            let time = new Array(len)
 
-            for (let i = 0; i < this.data.length; i++) {
+            for (let i = 0; i < len; i++) {
                 let inst_freq = this.data[i].freq
                 for (let j = 0; j < inst_freq.length; j++) {
                     inst_freq[j] = this.get_target(config, inst_freq[j])
                 }
 
-                time.push(this.data[i].time)
-                freq.push(inst_freq)
+                time[i] = this.data[i].time
+                freq[i] = inst_freq
             }
             return { freq:freq, time:time }
         }
@@ -1445,8 +1451,9 @@ function calculate_transfer_function() {
         }
 
         // Evaluate dynamic notches at each time step
-        let ret_H = []
-        for (let j = 0; j < time.length; j++) {
+        const len = time.length
+        let ret_H = new Array(len)
+        for (let j = 0; j < len; j++) {
 
             var H = { n: H_static.n, d: H_static.d }
             for (let k=0; k<filters.notch.length; k++) {
@@ -2031,8 +2038,9 @@ function redraw_Spectrogram() {
 
 
     // Setup z data
-    Spectrogram.data[0].z = []
-    for (j = 0; j<Gyro_batch[batch_instance].FFT[axis].length; j++) {
+    const len = Gyro_batch[batch_instance].FFT[axis].length
+    Spectrogram.data[0].z = new Array(len)
+    for (j = 0; j<len; j++) {
 
         var amplitude = array_scale(Gyro_batch[batch_instance].FFT[axis][j], window_correction)
         if (estimated) {
@@ -2212,8 +2220,8 @@ function get_param_value(param_log, name) {
 }
 
 function get_HNotch_param_names() {
-    prefix = ["INS_HNTCH_", "INS_HNTC2_"]
-    ret = []
+    let prefix = ["INS_HNTCH_", "INS_HNTC2_"]
+    let ret = []
     for (let i = 0; i < prefix.length; i++) {
         ret[i] = {enable: prefix[i] + "ENABLE",
                   mode: prefix[i] + "MODE",

--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -1311,6 +1311,8 @@ function setup_plots() {
 // Calculate if needed and re-draw, called from calculate button
 function re_calc() {
 
+    const start = performance.now()
+
     calculate()
 
     load_filters()
@@ -1318,6 +1320,9 @@ function re_calc() {
     calculate_transfer_function()
 
     redraw()
+
+    const end = performance.now();
+    console.log(`Re-calc took: ${end - start} ms`);
 }
 
 // Force full re-calc on next run, on window size change

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -301,13 +301,20 @@
 <tr>
 <td style="width: 30px;"></td>
 <td>
-    <fieldset style="width:1100px">
+    <fieldset style="width:532px;height:70px">
     <legend>Low pass filter</legend>
     <p>
         <label class="parameter_input_label" for="INS_GYRO_FILTER">INS_GYRO_FILTER</label>
         <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" style="width: 100px" onchange="filter_param_read()"/>
     </p>
-</fieldset>
+    </fieldset>
+<td>
+    <fieldset style="width:532px;height:70px">
+    <legend>Setup</legend>
+    <p>
+        <input type="button" id="calculate_filters" value="Recalculate filters" onclick="re_calc()">
+    </p>
+    </fieldset>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
This should be quite a nice speed up, it also reorders things so the log itself can be freed before we start using more memory in the FFT calculation. This also adds a new filter re-calc button that is closer to the filter config to avoid the need for constant scrolling.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/97d4c845-9552-4a02-8f24-e5f5870cfacf)

