### PR TITLE
FilterReview: add button to open in filter tool

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -474,7 +474,7 @@
 
 <table>
     <tr>
-        <td style="width:400px;"></td>
+        <td style="width:350px;"></td>
         <td>
             <fieldset style="width:125px">
                 <legend>Gyro instance</legend>
@@ -496,6 +496,10 @@
                 <input type="radio" id="ScaleWrap" name="PhaseScale" value="wrap"  onchange="redraw_post_estimate_and_bode()">
                 <label for="ScaleWrap">±180</label>
             </fieldset>
+        </td>
+        <td style="width:10px;"></td>
+        <td>
+            <input type="button" id="OpenFilterTool" value="Open in filter tool" onclick="open_in_filter_tool()">
         </td>
     </tr>
 </table>


### PR DESCRIPTION
This adds a button down at the bottom to open the current filter setup in the filter tool.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/52cb0979-3911-422d-abe2-82e9fc421ab8)

![image](https://github.com/ArduPilot/WebTools/assets/33176108/2ff92e8a-fade-450d-b518-62a49d828163)

The filter tool allows viewing of individual components (https://github.com/ArduPilot/WebTools/pull/21) that would be impractical to show over the whole log in the filter review tool.

