### PR TITLE
FilterReview: Add aliasing view

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -1741,15 +1741,15 @@ function redraw() {
             if ((filters.notch[i].harmonics() & (1<<j)) == 0) {
                 continue
             }
-            const harmonic_freq = frequency_scale.fun(mean * (j+1))
+            const harmonic_freq = frequency_scale.fun([mean * (j+1)])[0]
 
             const line_index = (i*max_num_harmonics*2) + j*2
             fft_plot.layout.shapes[line_index].visible = show_notch
             fft_plot.layout.shapes[line_index].x0 = harmonic_freq
             fft_plot.layout.shapes[line_index].x1 = harmonic_freq
 
-            const min_freq = frequency_scale.fun(min * (j+1))
-            const max_freq = frequency_scale.fun(max * (j+1))
+            const min_freq = frequency_scale.fun([min * (j+1)])[0]
+            const max_freq = frequency_scale.fun([max * (j+1)])[0]
 
             const range_index = line_index + 1
             fft_plot.layout.shapes[range_index].visible = show_notch

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -255,7 +255,6 @@
 
 <table>
     <tr>
-        <td style="width: 150px;"></td>
         <td>
             <fieldset style="width:300px;height:40px">
                 <legend>Amplitude scale</legend>
@@ -291,6 +290,17 @@
                 <label for="Notch2Show">Show notch 2</label>
             </fieldset>
         </td>
+        <td>
+            <fieldset style="width:240px;height:40px">
+                <legend>Loop Rate Aliasing</legend>
+                <input type="radio" id="Aliasing_none" name="Aliasing" onchange="redraw()" checked>
+                <label for="Aliasing_none">Hide</label>
+                <input type="radio" id="Aliasing_on" name="Aliasing" onchange="redraw()">
+                <label for="Aliasing_on">Show</label>
+                <input type="radio" id="Aliasing_only" name="Aliasing" onchange="redraw()">
+                <label for="Aliasing_only">Aliasing only</label>
+            </fieldset>
+        </td>
     </tr>
 </table>
 
@@ -302,15 +312,25 @@
 <tr>
 <td style="width: 30px;"></td>
 <td>
-    <fieldset style="width:532px;height:70px">
-    <legend>Low pass filter</legend>
+    <fieldset style="width:300px;height:70px">
+    <legend>Low Pass Filter</legend>
     <p>
         <label class="parameter_input_label" for="INS_GYRO_FILTER">INS_GYRO_FILTER</label>
         <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" style="width: 100px" onchange="filter_param_read()"/>
     </p>
     </fieldset>
+</td>
 <td>
-    <fieldset style="width:532px;height:70px">
+    <fieldset style="width:300px;height:70px">
+    <legend>Loop Rate</legend>
+    <p>
+        <label class="parameter_input_label" for="LOOP_RATE">SCHED_LOOP_RATE</label>
+        <input id="SCHED_LOOP_RATE" name="SCHED_LOOP_RATE" type="number" step="1" min="25" value="400" style="width: 100px" onchange="filter_param_read()"/>
+    </p>
+    </fieldset>
+</td>
+<td>
+    <fieldset style="width:428px;height:70px">
     <legend>Setup</legend>
     <p>
         <input type="button" id="calculate_filters" value="Recalculate filters" onclick="re_calc()">


### PR DESCRIPTION
This adds a aliasing view and loop rate param:
![image](https://github.com/ArduPilot/WebTools/assets/33176108/2a461a60-5567-4fc4-a392-09b30e8438b0)

When selected the whole frequency range is folded down into the niquist of the loop rate, this represents the noise the control loops actually see. For example this is the normal sub 200hz:

![image](https://github.com/ArduPilot/WebTools/assets/33176108/689881bc-f24b-4fe3-bfb8-aee641065162)

With aliasing on:

![image](https://github.com/ArduPilot/WebTools/assets/33176108/02bce572-d1d0-429a-b267-f150ed33c041)

The extra peaks are reflections from higher frequencies:

![image](https://github.com/ArduPilot/WebTools/assets/33176108/d7fc539c-cd3f-4bb6-93a3-f4e5801d9d22)

There is also the option to show only the aliasing, this removes the frequencies lower than the niquist and only shows the aliased signals reflected down from higher frequencies, this should be as close to 0 as posible.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/e1eb6847-069b-49c5-911a-b39c92d1fec0)
