### PR TITLE
FilterReview: bug fixes and highlight the primary gyro

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -163,6 +163,9 @@ class ThrottleTarget extends NotchTarget {
     }
 
     get_target(config, AOut) {
+        if (config.ref == 0) {
+            return config.freq
+        }
         const motors_throttle = Math.max(0, AOut)
         return config.freq * Math.max(config.min_ratio, Math.sqrt(motors_throttle / config.ref))
     }
@@ -179,6 +182,9 @@ class RPMTarget extends NotchTarget {
     }
 
     get_target(config, rpm) {
+        if (config.ref == 0) {
+            return config.freq
+        }
         if (rpm > 0) {
             return Math.max(config.freq, rpm * config.ref * (1.0/60.0))
         }
@@ -299,6 +305,9 @@ class ESCTarget extends NotchTarget {
     }
 
     get_target(config, rpm) {
+        if (config.ref == 0) {
+            return config.freq
+        }
         return Math.max(rpm, config.freq)
     }
 
@@ -425,6 +434,9 @@ class FFTTarget extends NotchTarget {
     }
 
     get_target(config, rpm) {
+        if (config.ref == 0) {
+            return config.freq
+        }
         return Math.max(rpm, config.freq)
     }
 
@@ -3027,7 +3039,22 @@ function load(log_file) {
             }
         }
     }
+
+    // If no primary display the first sensor the is data for in spectogram
+    if (primary_gyro == null) {
+        primary_gyro = first_gyro
+    }
+
+    // Default spectrograph to primary sensor, pre if available and X axis
+    document.getElementById("SpecGyroInst" + primary_gyro).checked = true
+    document.getElementById("BodeGyroInst" + primary_gyro).checked = true
+
+    document.getElementById("SpecGyro" + (Gyro_batch.have_pre ? "Pre" : "Post")).checked = true
     document.getElementById("SpecGyroEstPost").disabled = !Gyro_batch.have_pre
+    document.getElementById("SpecGyroAxisX").checked = true
+    document.getElementById("SpecGyroAxisX").disabled = false
+    document.getElementById("SpecGyroAxisY").disabled = false
+    document.getElementById("SpecGyroAxisZ").disabled = false
 
     // Calculate FFT
     calculate()

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -109,7 +109,7 @@
     <tr>
         <td style="width: 50px;"></td>
         <td>
-            <fieldset style="width:300px">
+            <fieldset id="Gyro0" style="width:300px">
                 <legend ondblclick="update_hidden(this)">Gyro 1</legend>
                 Sensor: <label id="Gyro0_info"></label>
                 <p>
@@ -156,7 +156,7 @@
              </fieldset>
         </td>
         <td>
-            <fieldset style="width:300px">
+            <fieldset id="Gyro1" style="width:300px">
                 <legend ondblclick="update_hidden(this)">Gyro 2</legend>
                 Sensor: <label id="Gyro1_info"></label>
                 <p>
@@ -203,7 +203,7 @@
             </fieldset>
         </td>
         <td>
-            <fieldset style="width:300px">
+            <fieldset id="Gyro2" style="width:300px">
                 <legend ondblclick="update_hidden(this)">Gyro 3</legend>
                 Sensor: <label id="Gyro2_info"></label>
                 <p>


### PR DESCRIPTION
If it can workout the primary gyro from params the tool will now highlight that sensor with a green box and adding "Primary". It will then only plot that sensor by default, this makes it less overwhelming on first plot.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/f3148b75-edf3-4573-9a0c-30c38aa8fc2a)
 
This also fixes a bug there the post filter estimate would use the incorrect value if the reference was not set, now it correctly defaults to a static filter at the set frequency.