### PR TITLE
FilterReview: Fix ESC and FFT sticky min freq

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -324,9 +324,10 @@ class ESCTarget extends NotchTarget {
             let time = new Array(len)
 
             for (let i = 0; i < len; i++) {
-                let inst_freq = this.data[i].freq
-                for (let j = 0; j < inst_freq.length; j++) {
-                    inst_freq[j] = this.get_target(config, inst_freq[j])
+                const inst_len = this.data[i].freq.length
+                let inst_freq = new Array(inst_len)
+                for (let j = 0; j < inst_len; j++) {
+                    inst_freq[j] = this.get_target(config, this.data[i].freq[j])
                 }
 
                 time[i] = this.data[i].time
@@ -337,9 +338,10 @@ class ESCTarget extends NotchTarget {
         }
 
         // Tracking average motor rpm
-        let freq = this.data.avg_freq
-        for (let j = 0; j < freq.length; j++) {
-            freq[j] = this.get_target(config, freq[j])
+        const len = this.data.avg_freq.length
+        let freq = new Array(len)
+        for (let j = 0; j < len; j++) {
+            freq[j] = this.get_target(config, this.data.avg_freq[j])
         }
 
         return { freq:freq, time:this.data.avg_time }
@@ -453,9 +455,10 @@ class FFTTarget extends NotchTarget {
             let time = new Array(len)
 
             for (let i = 0; i < len; i++) {
-                let inst_freq = this.data[i].freq
-                for (let j = 0; j < inst_freq.length; j++) {
-                    inst_freq[j] = this.get_target(config, inst_freq[j])
+                const inst_len = this.data[i].freq.length
+                let inst_freq = new Array(inst_len)
+                for (let j = 0; j < inst_len; j++) {
+                    inst_freq[j] = this.get_target(config, this.data[i].freq[j])
                 }
 
                 time[i] = this.data[i].time
@@ -465,9 +468,10 @@ class FFTTarget extends NotchTarget {
         }
 
         // Just center peak
-        let freq = this.data.value
-        for (let j = 0; j < freq.length; j++) {
-            freq[j] = this.get_target(config, freq[j])
+        const len = this.data.value.length
+        let freq = new Array(len)
+        for (let j = 0; j < len; j++) {
+            freq[j] = this.get_target(config, this.data.value[j])
         }
         return { freq:freq, time:this.data.time }
     }


### PR DESCRIPTION
js pass by reference behavior here was resulting in the updated values getting put back in to the stored reference, this meant that the source data had the min freq constrain applied so the min freq could not be lowered later. The fix is to use a new array for the data to break that link. 