### PR TITLE
All: add new "open in" functionality to pass logs bettween tools

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="../Libraries/FileSaver.js"></script>
 <script type="text/javascript" src="../Libraries/ParameterMetadata.js"></script>
 <script type="text/javascript" src="../Libraries/fft.js"></script>
+<script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 
 </head>
 <table style="width:1200px"><tr><td>
@@ -86,6 +87,7 @@
             <td style="width: 10px;"></td>
             <td>
                 <input id="fileItem" type="file" accept=".bin" onchange="readFile(this)"><br><br>
+                <div id="OpenIn"></div><br><br>
                 <input type="button" id="calculate" value="Calculate" onclick="re_calc()">
             </td>
         </tr>
@@ -551,5 +553,7 @@
         }
         reader.readAsArrayBuffer(file)
     }
+
+    setup_open_in("OpenIn", "fileItem", load)
 
 </script>

--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -7,6 +7,7 @@
 <script type="text/javascript" src="../Libraries/DecodeDevID.js"></script>
 <script type="text/javascript" src="../Libraries/FileSaver.js"></script>
 <script type="text/javascript" src="../Libraries/Array_Math.js"></script>
+<script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
 
 </head>
@@ -34,6 +35,8 @@
 
 <body onload="initial_load(); reset();">
 <input id="fileItem" type="file" accept=".param,.parm,.bin" onchange="load(this)">
+
+<div id="OpenIn"></div>
 
 <h3 hidden>Firmware</h3>
 <p id="VER"></p>
@@ -241,6 +244,8 @@
             'Line Number: '+ linenumber)
       return false
   }
+
+  setup_open_in("OpenIn", "fileItem", (data) => {reset(); load_log(data)})
 
 </script>
 

--- a/Libraries/OpenIn.js
+++ b/Libraries/OpenIn.js
@@ -1,0 +1,95 @@
+// Helper to create a "open in" drop down to pass logs between tools
+
+function setup_open_in(div_id, file_id, load_fun) {
+
+    // Setup main div
+    let div = document.getElementById(div_id)
+    div.style = "display: inline-block; position: relative;"
+
+    const width = "125px"
+
+    // Add button
+    let button = document.createElement("button")
+    button.innerHTML = "Open In"
+    button.style.width = width
+    button.disabled = true
+    div.appendChild(button)
+
+    // Add drop down div
+    let dropdown = document.createElement("div")
+    dropdown.style = "display: none; position: absolute; width: 100%; overflow: auto; box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);"
+    div.appendChild(dropdown)
+
+    // Show and hide drop down
+    div.addEventListener("mouseover", () => {
+        // only show if button is enabled
+        if (!button.disabled) {
+            dropdown.style.display = "block"
+        }
+    });
+
+    // Always hide
+    div.addEventListener("mouseout", () => { dropdown.style.display = "none" });
+
+    const destinations = [["UAV Log Viewer", "https://plotbeta.ardupilot.org/#"],
+                          ["Hardware Report", "/HardwareReport"],
+                          ["Filter Review","/FilterReview"], 
+                          ["PID Review", "/PIDReview"]]
+
+    const own_window = window.location.pathname
+    for (const dest of destinations) {
+        if (own_window.startsWith(dest[1])) {
+            // Don't link back to self
+            continue
+        }
+
+        // Button for each
+        let link = document.createElement("button")
+        link.innerHTML = dest[0]
+        link.style = "display: block; color: #000000; padding: 5px; text-decoration: none;"
+        link.style.width = width
+        dropdown.appendChild(link)
+
+        link.addEventListener('click', function() {
+            // Get current file
+            const file = document.getElementById(file_id).files[0]
+            if (file == null) {
+                return
+            }
+
+            const reader = new FileReader()
+            reader.onload = function(e) {
+              const arrayBuffer = e.target.result
+        
+              // Open the new page and keep a reference to it
+              const newWindow = window.open(dest[1])
+        
+              // Wait a bit to ensure the new page is fully loaded
+              setTimeout(() => {
+                // Send the ArrayBuffer to the new window using postMessage
+                newWindow.postMessage({ type: 'arrayBuffer', data: arrayBuffer}, '*')
+              }, 2000)
+            }
+
+            // Load file
+            reader.readAsArrayBuffer(file)
+
+        })
+ 
+    }
+
+    // Add callback to auto enable button when log is added
+    const file_input = document.getElementById(file_id)
+    file_input.addEventListener('change', function() {
+        const file = document.getElementById(file_id).files[0]
+        button.disabled = (file == null) || !file.name.toLowerCase().endsWith(".bin")
+    })
+
+    // Load from "open in" button on other pages
+    window.addEventListener('message', (event) => {
+        if (event.data.type === 'arrayBuffer') {
+            load_fun(event.data.data)
+        }
+    })
+
+}

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -9,6 +9,7 @@
 <script type="text/javascript" src="PIDReview.js"></script>
 <script type="text/javascript" src="../Libraries/Array_Math.js"></script>
 <script type="text/javascript" src="../Libraries/fft.js"></script>
+<script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 
 </head>
 <table style="width:1200px"><tr><td>
@@ -100,6 +101,7 @@
         <td style="width: 10px;"></td>
         <td>
             <input id="fileItem" type="file" accept=".bin" onchange="readFile(this)"><br><br>
+            <div id="OpenIn"></div><br><br>
             <input type="button" id="calculate" value="Calculate" onclick="re_calc()">
         </td>
     </table>
@@ -283,5 +285,7 @@
         }
         reader.readAsArrayBuffer(file)
     }
+
+    setup_open_in("OpenIn", "fileItem", load)
 
 </script>


### PR DESCRIPTION
Many thanks to @Williangalvani for working out how we could do this and adding support to plot.ardupilot, https://github.com/ArduPilot/UAVLogViewer/pull/403

This adds buttons to pass logs back and forth between tools, once a log is loaded a drop down will become available to load the log in a tool in a new window.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/5d30c6be-1ca4-4fa4-9a39-c8c1ffaebf7b)

![image](https://github.com/ArduPilot/WebTools/assets/33176108/16ba6ab8-4683-4ee1-a16f-ec10fb009d2e)

Note that this has only be tested locally, it seems to work between tools, but not to UAV Log Viewer. 
