### PR TITLE
all: add loading overlay for logs

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="../Libraries/ParameterMetadata.js"></script>
 <script type="text/javascript" src="../Libraries/fft.js"></script>
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
+<script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 
 </head>
 <table style="width:1200px"><tr><td>
@@ -88,7 +89,7 @@
             <td>
                 <input id="fileItem" type="file" accept=".bin" onchange="readFile(this)"><br><br>
                 <div id="OpenIn"></div><br><br>
-                <input type="button" id="calculate" value="Calculate" onclick="re_calc()">
+                <input type="button" id="calculate" value="Calculate" onclick="loading_call(re_calc)">
             </td>
         </tr>
     </table>
@@ -335,7 +336,7 @@
     <fieldset style="width:428px;height:70px">
     <legend>Setup</legend>
     <p>
-        <input type="button" id="calculate_filters" value="Recalculate filters" onclick="re_calc()">
+        <input type="button" id="calculate_filters" value="Recalculate filters" onclick="loading_call(re_calc)">
         <input type="button" id="SaveParams" value="Save Parameters" onclick="save_parameters();">
         <button class="styleClass" id="LoadParams" onclick="document.getElementById('LoadParamsbase').click()">Load Parameters</button>
         <input type='file' id="LoadParamsbase" style="display:none" onchange="load_parameters(this.files[0]);">
@@ -549,11 +550,13 @@
         }
         let reader = new FileReader()
         reader.onload = function (e) {
-            load(reader.result)
+            loading_call(() => { load(reader.result) })
         }
         reader.readAsArrayBuffer(file)
     }
 
-    setup_open_in("OpenIn", "fileItem", load)
+    setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
+
+    init_loading_overlay()
 
 </script>

--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1269,7 +1269,7 @@ async function load(e) {
     if (file.name.toLowerCase().endsWith(".bin")) {
         let reader = new FileReader()
         reader.onload = function (e) {
-            load_log(reader.result)
+            loading_call(() => { load_log(reader.result) })
         }
         reader.readAsArrayBuffer(file)
 

--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -8,6 +8,7 @@
 <script type="text/javascript" src="../Libraries/FileSaver.js"></script>
 <script type="text/javascript" src="../Libraries/Array_Math.js"></script>
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
+<script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
 
 </head>
@@ -245,7 +246,9 @@
       return false
   }
 
-  setup_open_in("OpenIn", "fileItem", (data) => {reset(); load_log(data)})
+  setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { reset(); load_log(data) }) })
+
+  init_loading_overlay()
 
 </script>
 

--- a/Libraries/LoadingOverlay.js
+++ b/Libraries/LoadingOverlay.js
@@ -1,0 +1,48 @@
+// Helper to add a loading overlay to a page and show/hide it
+
+function init_loading_overlay() {
+
+    let div = document.createElement("div")
+    div.id = "loading"
+    div.style.position = "fixed"
+    div.style.top = 0
+    div.style.left = 0
+    div.style.width = "100%"
+    div.style.height = "100%"
+    div.style.opacity = 0.7
+    div.style.backgroundColor = "#fff"
+    div.style.zIndex = 99
+    div.style.visibility = "hidden"
+
+    let text = document.createElement("h1")
+    text.style.position = "absolute"
+    text.style.top = "50%"
+    text.style.left = "50%"
+    text.style.transform = "translate(-50%, -50%)"
+    text.innerHTML = "Loading"
+
+    div.appendChild(text)
+    document.body.appendChild(div)
+
+}
+
+function loading_call(fun) {
+
+    // Show loading screen
+    let overlay = document.getElementById("loading")
+    overlay.style.visibility = 'visible'
+
+    // https://forum.freecodecamp.org/t/how-to-make-js-wait-until-dom-is-updated/122067/2
+
+    // this double requestAnimationFrame ensures that the loading screen is rendered before the load starts
+
+    let intermediate = function () { window.requestAnimationFrame(() => {
+            // Call the passed in function
+            fun()
+
+            // Hide loading screen
+            overlay.style.visibility = 'hidden'
+    })}
+    window.requestAnimationFrame(intermediate)
+
+}

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -1740,6 +1740,16 @@ function load(log_file) {
     // Calculate FFT
     calculate()
 
+    // Setup the selected axis
+    setup_axis()
+
+    const end = performance.now();
+    console.log(`Load took: ${end - start} ms`);
+}
+
+// Setup the selected axis
+function setup_axis() {
+
     // Show param values
     add_param_sets()
 
@@ -1748,7 +1758,4 @@ function load(log_file) {
 
     // Plot
     redraw()
-
-    const end = performance.now();
-    console.log(`Load took: ${end - start} ms`);
 }

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="../Libraries/Array_Math.js"></script>
 <script type="text/javascript" src="../Libraries/fft.js"></script>
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
+<script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 
 </head>
 <table style="width:1200px"><tr><td>
@@ -72,27 +73,27 @@
                 <legend>Axis</legend>
                 <table>
                     <td>
-                        <input type="radio" id="type_RATE_R" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_RATE_R" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_RATE_R">RATE Roll</label><br>
-                        <input type="radio" id="type_RATE_P" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_RATE_P" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_RATE_P">RATE Pitch</label><br>
-                        <input type="radio" id="type_RATE_Y" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_RATE_Y" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_RATE_Y">RATE Yaw</label><br>
                     </td>
                     <td>
-                        <input type="radio" id="type_PIDR" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIDR" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDR">PIDR</label><br>
-                        <input type="radio" id="type_PIDP" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIDP" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDP">PIDP</label><br>
-                        <input type="radio" id="type_PIDY" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIDY" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIDY">PIDY</label><br>
                     </td>
                     <td>
-                        <input type="radio" id="type_PIQR" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIQR" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIQR">PIQR</label><br>
-                        <input type="radio" id="type_PIQP" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIQP" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIQP">PIQP</label><br>
-                        <input type="radio" id="type_PIQY" name="Axis" onchange="add_param_sets(); setup_FFT_data(); redraw()">
+                        <input type="radio" id="type_PIQY" name="Axis" onchange="loading_call(setup_axis)">
                         <label for="type_PIQY">PIQY</label><br>
                     </td>
                 </table>
@@ -102,7 +103,7 @@
         <td>
             <input id="fileItem" type="file" accept=".bin" onchange="readFile(this)"><br><br>
             <div id="OpenIn"></div><br><br>
-            <input type="button" id="calculate" value="Calculate" onclick="re_calc()">
+            <input type="button" id="calculate" value="Calculate" onclick="loading_call(re_calc)">
         </td>
     </table>
 </fieldset>
@@ -281,11 +282,13 @@
         }
         let reader = new FileReader()
         reader.onload = function (e) {
-            load(reader.result)
+            loading_call(() => { load(reader.result) })
         }
         reader.readAsArrayBuffer(file)
     }
 
-    setup_open_in("OpenIn", "fileItem", load)
+    setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
+
+    init_loading_overlay()
 
 </script>


### PR DESCRIPTION
This adds a simple loading overlay that shows while the log is loading. No fancy spinner or anything yet. 

Just dims the main page and adds "loading" in the middle of the window. 

![image](https://github.com/ArduPilot/WebTools/assets/33176108/27dab8a2-96c0-4602-a071-3e7aca8fd903)

Logs only, where a param file is loaded its so quick that there is no point, so filter tool and hardware review from param file are not changed. 