### PR TITLE
FilterReview: use correct sample rate for post filter estimate

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -1300,7 +1300,7 @@ function calculate() {
         if (!Gyro_batch[i].post_filter) {
             // Calculate Z for transfer function
             // Z = e^jw
-            const Z = exp_jw(Gyro_batch[i].FFT.bins, Gyro_batch[i].gyro_rate)
+            const Z = exp_jw(Gyro_batch[i].FFT.bins, Gyro_batch[i].FFT.average_sample_rate)
 
             // Z^-1
             Gyro_batch[i].FFT.Z1 = complex_inverse(Z)
@@ -1320,7 +1320,7 @@ function calculate() {
 
             // Calculate Z for transfer function
             // Z = e^jw
-            const bode_Z = exp_jw(Gyro_batch[i].FFT.bode.freq, Gyro_batch[i].gyro_rate)
+            const bode_Z = exp_jw(Gyro_batch[i].FFT.bode.freq, Gyro_batch[i].FFT.average_sample_rate)
 
             // Z^-1
             Gyro_batch[i].FFT.bode.Z1 = complex_inverse(bode_Z)
@@ -1386,14 +1386,14 @@ function calculate_transfer_function() {
         }
         if (Gyro_batch[i].FFT.Z1 != null) {
             // Calc transfer functions for post filter estimate
-            Gyro_batch[i].FFT.H = calc(i, Gyro_batch[i].FFT.time, Gyro_batch[i].gyro_rate, Gyro_batch[i].FFT.Z1, Gyro_batch[i].FFT.Z2)
+            Gyro_batch[i].FFT.H = calc(i, Gyro_batch[i].FFT.time, Gyro_batch[i].FFT.average_sample_rate, Gyro_batch[i].FFT.Z1, Gyro_batch[i].FFT.Z2)
 
         }
         if (Gyro_batch[i].FFT.bode != null) {
             // Use post filter if available
 
             // Higher frequency resolution for bode plot
-            Gyro_batch[i].FFT.bode.H = calc(i, Gyro_batch[i].FFT.time, Gyro_batch[i].gyro_rate, Gyro_batch[i].FFT.bode.Z1, Gyro_batch[i].FFT.bode.Z2)
+            Gyro_batch[i].FFT.bode.H = calc(i, Gyro_batch[i].FFT.time, Gyro_batch[i].FFT.average_sample_rate, Gyro_batch[i].FFT.bode.Z1, Gyro_batch[i].FFT.bode.Z2)
         }
     }
 


### PR DESCRIPTION
When using fast sampling using the logged gyro rate to apply the filters at is not correct. The logging rate is a better estimate of the rate the filters are actually applied at.

Before there is a amplitude error that increases with frequency:
![before big](https://github.com/ArduPilot/WebTools/assets/33176108/9f7ef815-f227-439f-bda9-2692ebb4a217)

![before](https://github.com/ArduPilot/WebTools/assets/33176108/618dd052-f1e1-49b4-b97f-16fe0b76ae69)

After results are extremely close up to the the last 100Hz or so:
![after big](https://github.com/ArduPilot/WebTools/assets/33176108/5ebae4c9-f539-4d7a-884e-b5e4d5d7790c)

![after](https://github.com/ArduPilot/WebTools/assets/33176108/b0d6c5bd-bff6-479c-bdc3-1a7fa6ea072e)

