### PR TITLE
All: add missing methods to allow removal of mathjs package

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -1222,7 +1222,7 @@ function calculate() {
             const max_freq = Gyro_batch[i].FFT.bins[Gyro_batch[i].FFT.bins.length  - 1]
 
             Gyro_batch[i].FFT.bode = []
-            Gyro_batch[i].FFT.bode.freq = math.range(0, max_freq, freq_step, true)._data
+            Gyro_batch[i].FFT.bode.freq = array_from_range(0, max_freq, freq_step)
 
             // Calculate Z for transfer function
             // Z = e^jw
@@ -2654,7 +2654,7 @@ function load(log_file) {
                 }
                 if (msg_key != null) {
                     // Assume constant rate, this is not actually true, but variable rate breaks FFT averaging.
-                    gyro_rate[i] = math.mean(Array.from(log.messages[msg_key].GHz))
+                    gyro_rate[i] = array_mean(Array.from(log.messages[msg_key].GHz))
                 }
 
             }

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8" />
 <title>ArduPilot Filter Review Tool</title>
 <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
-<script src="https://unpkg.com/mathjs/lib/browser/math.js"></script>
 <script src="https://unpkg.com/browser-cjs/require.min.js"></script>
 <script type="text/javascript" src="FilterReview.js"></script>
 <script type="text/javascript" src="../Libraries/DecodeDevID.js"></script>

--- a/FilterTool/filters.js
+++ b/FilterTool/filters.js
@@ -393,7 +393,7 @@ function unwrap(phase) {
 function evaluate_transfer_functions(filter_groups, freq_max, freq_step, use_dB, unwrap_phase) {
 
     // Not sure why range does not return expected array, _data gets us the array
-    const freq = math.range(freq_step, freq_max, freq_step, true)._data
+    const freq = array_from_range(freq_step, freq_max, freq_step)
 
     // Start with unity transfer function, input = output
     const len = freq.length

--- a/FilterTool/index.html
+++ b/FilterTool/index.html
@@ -10,7 +10,6 @@
 <script type="text/javascript" src="../Libraries/Plotly_helpers.js"></script>
 
 <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
-<script src="https://unpkg.com/mathjs/lib/browser/math.js"></script>
 </head>
 <table style="width:1200px"><tr><td>
     <a href="https://ardupilot.org"><img src="../images/ArduPilot.png"></a>

--- a/Libraries/Array_Math.js
+++ b/Libraries/Array_Math.js
@@ -195,6 +195,27 @@ function array_abs(A) {
     return ret
 }
 
+function array_mean(A) {
+    const len = A.length
+    let ret = 0
+    for (let i = 0; i<len; i++) {
+        ret += A[i]
+    }
+    return ret / len
+}
+
+// Return a range, including start and end points
+function array_from_range(start, end, step) {
+    const len = Math.floor((end - start) / step) + 1
+    let val = start
+    let ret = new Array(len)
+    for (let i = 0; i<len; i++) {
+        ret[i] = val
+        val += step
+    }
+    return ret
+}
+
 // Linear interpolation between arrays
 function linear_interp(values, index, query_index) {
 

--- a/Libraries/fft.js
+++ b/Libraries/fft.js
@@ -16,8 +16,8 @@ function hanning(len) {
 // energy: 1 / sqrt(mean(w.^2))
 function window_correction_factors(w) {
     return {
-        linear: 1/math.mean(w),
-        energy: 1/Math.sqrt(math.mean(array_mul(w,w)))
+        linear: 1/array_mean(w),
+        energy: 1/Math.sqrt(array_mean(array_mul(w,w)))
     }
 }
 

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -862,8 +862,8 @@ function redraw() {
     // Rectangles to show param changes
     if (PID.params.sets.length > 1) {
         for (let i = 0; i < PID.params.sets.length; i++) {
-            const set_start = math.max(time_range[0], PID.params.sets[i].start_time)
-            const set_end = math.min(time_range[1], PID.params.sets[i].end_time)
+            const set_start = Math.max(time_range[0], PID.params.sets[i].start_time)
+            const set_end = Math.min(time_range[1], PID.params.sets[i].end_time)
 
             TimeInputs.layout.shapes[i].x0 = set_start
             TimeInputs.layout.shapes[i].x1 = set_end

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8" />
 <title>ArduPilot PID Review Tool</title>
 <script src='https://cdn.plot.ly/plotly-2.20.0.min.js'></script>
-<script src="https://unpkg.com/mathjs/lib/browser/math.js"></script>
 <script src="https://unpkg.com/browser-cjs/require.min.js"></script>
 <script type="text/javascript" src="PIDReview.js"></script>
 <script type="text/javascript" src="../Libraries/Array_Math.js"></script>


### PR DESCRIPTION
We were missing a array mean and array range function. This adds those to our `Array_Math` lib removing the dependency on `mathjs`.