### PR TITLE
stopped fault in FilterTool

### DIFF
--- a/Libraries/ParameterMetadata.js
+++ b/Libraries/ParameterMetadata.js
@@ -172,7 +172,9 @@ async function load_param_inputs(param_doc, param_names) {
                 }
 
                 param.value = value
-                param.onchange()
+                if (typeof param.onchange === 'function') {
+                    param.onchange()
+                }
             }
 
             paragaph.appendChild(document.createElement('br'))


### PR DESCRIPTION
param.onchange() doesn't exist, impacts harmonic tick boxes