### PR TITLE
FilterTool: fix "get link" formatting and parsing.

### DIFF
--- a/FilterTool/filters.js
+++ b/FilterTool/filters.js
@@ -832,8 +832,12 @@ function get_link() {
     // Add all query strings
     var sections = ["params", "PID_params"];
     for (var j = 0; j<sections.length; j++) {
-        var items = document.forms[sections[j]].getElementsByTagName("input");
+        var items = document.forms[sections[j]].querySelectorAll('input,select');
         for (var i=-0;i<items.length;i++) {
+            if (items[i].name === "") {
+                // Invalid name
+                continue
+            }
             if (items[i].type == "radio" && !items[i].checked) {
                 // Only add checked radio buttons
                 continue;

--- a/FilterTool/index.html
+++ b/FilterTool/index.html
@@ -96,7 +96,7 @@ ArduPilot 4.2 filter setup.
   <legend>INS Settings</legend>
         <p>
                 <label for="GyroSampleRate">Gyro Sample Rate</label>
-                <input id="GyroSampleRate" name="GYRO_SAMPLE_RATE" type="number" step="1" value="2000"/>
+                <input id="GyroSampleRate" name="GyroSampleRate" type="number" step="1" value="2000"/>
 	</p>
         <p>
                 <input id="INS_GYRO_FILTER" name="INS_GYRO_FILTER" type="number" step="0.1" value="20.0" style="width: 100px"/>


### PR DESCRIPTION
The "get link" button was missing mode and enabled as they are now "select" types rather than "input" and gyro sample rate was missed because the ID and name did not match. 
