### PR TITLE
MAGFit: ignore battery current if all zero

### DIFF
--- a/MAGFit/magfit.js
+++ b/MAGFit/magfit.js
@@ -2034,7 +2034,7 @@ function load(log_file) {
                 continue
             }
             const value = Array.from(log.messages[msg_name].Curr)
-            if (array_all_NaN(value)) {
+            if (array_all_NaN(value) || array_all_equal(0)) {
                 // Battery does not support current
                 continue
             }


### PR DESCRIPTION
Fixes https://github.com/ArduPilot/WebTools/issues/83

In the log battery current was all zero, this would be the case if the monitor could read current but was not configured to. No variation in the current causes the matrix to be rank deficient and the solver errors out. 

I also have a patch that puts a try - catch around the solve, that would also fix but may prevent the reporting of such issues in the future. 