### PR TITLE
HardwareReport: add downloading of missions and fence

### DIFF
--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -229,6 +229,9 @@
 
 </p>
 
+<h3 hidden>Waypoints</h3>
+<p id="WAYPOINTS"></p>
+
 <h3 hidden>Files</h3>
 <p id="FILES"></p>
 


### PR DESCRIPTION
Adds download links for any mission or fence found in the log.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/3e558fb5-b9c8-40b0-8f90-abb0b851c0ab)

It will attempt not to provide multiple files for the same thing as Mission planner sometimes does. 