### PR TITLE
HardwareReport: be annoying if arming checks are disabled

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -875,6 +875,12 @@ function load_params(log) {
     update_minimal_config()
 
     update_pos_plot()
+
+    // Be annoying if arming checks are disabled
+    if (("ARMING_CHECK" in params) && (params.ARMING_CHECK == 0)) {
+        alert("Arming checks disabled")
+    }
+
 }
 
 function load_param_file(text) {


### PR DESCRIPTION
Does what it says on the tin.

Would like to have param view to show the full bitmask, but for that to work we need to make the tool build type aware so we load the correct param documentation. 