### PR TITLE
HardwareReport: add internal errors

### DIFF
--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -44,6 +44,9 @@
 <h3 hidden>Watchdog</h3>
 <p id="WDOG"></p>
 
+<h3 hidden>Internal Errors</h3>
+<p id="InternalError"></p>
+
 <h3 hidden>IOMCU</h3>
 <p id="IOMCU"></p>
 


### PR DESCRIPTION
Adds decoding of internal errors from `PM` or `MON` logs.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/adc33ece-359f-4364-bcfb-40b88f639155)
