### PR TITLE
Hardware Report and PIDReview: fixes for 4.0

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -451,7 +451,11 @@ function show_internal_errors(log) {
     let internal_errors = []
 
     // Add from PM
-    if (('PM' in log.messages) && (Object.keys(log.messages.PM).length > 0)) {
+    if (('PM' in log.messages) &&
+        ("time_boot_ms" in log.messages.PM) &&
+        ("IntE" in log.messages.PM) &&
+        ("ErrL" in log.messages.PM) &&
+        ("ErrC" in log.messages.PM)) {
         const len = log.messages.PM.time_boot_ms.length
         for (let i = 0; i < len; i++) {
             internal_errors.push({

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -717,6 +717,10 @@ function add_param_sets() {
             set_cell_style(item, color)
 
             const value = set[name]
+            if (value == null) {
+                continue
+            }
+
             const text = document.createTextNode(value.toFixed(4))
 
             let changed = false


### PR DESCRIPTION
A couple of easy fixes that lets a log from 4.0 load. We were looking for log fields that were mission in hardware report and looking for params that are missing in PID Review.