### PR TITLE
FilterReview: add the ability to plot logged notch frequency on spectogram

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -531,7 +531,16 @@ These params can then be saved and loaded into the autopilot without the need fo
         </td>
         <td>
             <fieldset style="width:350px;height:40px">
-                <legend>Filtering</legend>
+                <legend>Filtering
+                    <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
+                    data-tippy-allowHTML="true"
+                    data-tippy-content='<ul>
+                                        <li>Pre-filter: Logged IMU spectrum prior to application of filters.</li>
+                                        <li>Post-filter: Logged IMU spectrum including application of filters.</li>
+                                        <li>Estimated post-filter: Estimated IMU spectrum including application of filters as configured in Filter Configuration.</li>
+                                        </ul>'
+                    data-tippy-maxWidth='750px'/>
+                </legend>
                 <input type="radio" id="SpecGyroPre" name="SpecGyroPrePost" onchange="redraw_Spectrogram()">
                 <label for="SpecGyroPre">Pre-filter</label>
 
@@ -557,12 +566,20 @@ These params can then be saved and loaded into the autopilot without the need fo
         </td>
         <td>
             <fieldset style="width:240px;height:40px">
-                <legend>Notch tracking</legend>
+                <legend>Notch tracking
+                    <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
+                    data-tippy-content='Show/hide the center frequency and movement range of enabled notch filters. These should line up with noise peaks.
+                                        Logged shows the logged notch frequencies from the log, these will not change with parameter changes.',
+                    data-tippy-maxWidth='750px'/>
+                </legend>
                 <input type="checkbox" id="SpecNotch1Show" name="SpecNotch1Show" onchange="update_hidden_spec(this)">
-                <label for="SpecNotch1Show">Show notch 1</label>
+                <label for="SpecNotch1Show">Notch 1</label>
 
                 <input type="checkbox" id="SpecNotch2Show" name="SpecNotch2Show" onchange="update_hidden_spec(this)">
-                <label for="SpecNotch2Show">Show notch 2</label>
+                <label for="SpecNotch2Show">Notch 2</label>
+
+                <input type="checkbox" id="SpecNotchShowLogged" name="SpecNotchShowLogged" onchange="update_logged_notch_hidden_spec(this)">
+                <label for="SpecNotchShowLogged">Logged</label>
             </fieldset>
         </td>
     </tr>


### PR DESCRIPTION
This is more because its useful to verify the tool than because its useful for log review. This allows the tools estimated notch center frequencies to be compared to the real notch frequencies from log.  

This adds a new logged check box and a tool top for the notch tracking box.
![image](https://github.com/ArduPilot/WebTools/assets/33176108/32586a83-daa2-4cf2-a9a1-2b9cff17a2c2)

![image](https://github.com/ArduPilot/WebTools/assets/33176108/2d7e5494-81ae-4d62-8918-4465d0e9ac4f)

![image](https://github.com/ArduPilot/WebTools/assets/33176108/d14ceab3-f79c-483d-b7a2-426bef2ba6ee)

Before any parameter changes the logged should agree with the estimated. 