### PR TITLE
MAGFit: improve text and tool tip wording.

### DIFF
--- a/MAGFit/index.html
+++ b/MAGFit/index.html
@@ -49,7 +49,7 @@
 <body>
 
 <p style="width:1150px; text-align:justify; padding-left:30px; margin-block-start: 0; margin-block-end: 0.5em;">
-This tool takes a .bin log and performs a "MAGFit inflight calibration". Calibration parameters are found that fit the measured magnetic field from the log to the predicted field from the World Magnetic Model.
+This tool takes a .bin log and performs a "MAGFit inflight calibration". Calibration parameters are found that fit the measured magnetic field from the log to the expected field from the World Magnetic Model.
 For best results use a flight log that covers as many orientations as possible. Flying figure of eight patterns works well. If you need a motor calibration using either throttle or a current reading then you should also cover as wide a range of throttles and current draws as possible. You do not have to be in any particular flight mode.
 </p>
 
@@ -163,7 +163,7 @@ For best results use a flight log that covers as many orientations as possible. 
     <h2 style="text-align:center">Field length
         <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
         data-tippy-content='Comparison of field length &radic;(X&#178; + Y&#178; + Z&#178;). field length errors may coincide with current draw.
-                            Significant correlation could mean using battery compensation would give better results, if correlation remains when using a compensated fit a hardware fix may been required to move the compass further from the interference source.'
+                            Significant correlation could mean using battery compensation would give better results, if correlation remains when using a compensated calibration a hardware fix may been required to move the compass further from the interference source.'
         data-tippy-maxWidth='750px'/>
     </h2>
 </td></tr></table>
@@ -173,8 +173,8 @@ For best results use a flight log that covers as many orientations as possible. 
 <table><tr><td style="width:1200px">
     <h2 style="text-align:center">Motor compensation sources
         <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
-        data-tippy-content='Battery current for comparison with field length and fit error. 
-                            Significant correlation could mean using battery compensation would give better results, if correlation remains when using a compensated fit a hardware fix may been required to move the compass further from the interference source.'
+        data-tippy-content='Battery current for comparison with field length and calibration error. 
+                            Significant correlation could mean using battery compensation would give better results, if correlation remains when using a compensated calibration a hardware fix may been required to move the compass further from the interference source.'
         data-tippy-maxWidth='750px'/>
     </h2>
 </td></tr></table>
@@ -182,10 +182,10 @@ For best results use a flight log that covers as many orientations as possible. 
 <div id="motor_comp" style="width:1200px;height:300px"></div>
 
 <table><tr><td style="width:1200px">
-    <h2 style="text-align:center">Fit error
+    <h2 style="text-align:center">Calibration error
         <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
-        data-tippy-content='First plot is error of selected fit over time. Second plot is mean error compared for all fits, the value is the normalized area under the curve of the first plot. 
-        Error over time can be used to correlate with compensation sources. Mean error can be used to compare between fits.'
+        data-tippy-content='First plot shows the error (e.g. difference) over time between the selected calibrations and the expected world magnetic model. Second plot is mean error compared for all selected, the value is the normalized area under the curve of the first plot. 
+        Error over time can be used to correlate with compensation sources. Mean error can be used to compare between calibrations.'
         data-tippy-maxWidth='750px'/>
     </h2>
 </td></tr></table>

--- a/MAGFit/magfit.js
+++ b/MAGFit/magfit.js
@@ -2010,7 +2010,7 @@ function load(log_file) {
             continue
         }
 
-        const tip_text = "Fits with no motor compensation.<ul><li>Offsets: Fit of only X Y Z offset parameters.</li><li>Offsets and scale: Fit of X Y Z offsets and single scale factor.</li><li>Offsets and iron: Fit of X Y Z offsets and iron compensation matrix diagonals and off-diagonals.</li></ul>"
+        const tip_text = "Calibrations with no motor compensation.<ul><li>Offsets: calibration of only X Y Z offset parameters.</li><li>Offsets and scale: calibration of X Y Z offsets and single scale factor.</li><li>Offsets and iron: calibration of X Y Z offsets and iron compensation matrix diagonals and off-diagonals.</li></ul> If a calibration cannot be selected the tool was unable to find a valid solution, a longer flight with better coverage will give a better chance of finding a solution."
 
         MAG_Data[i].fits.push({
             value: null,
@@ -2043,7 +2043,7 @@ function load(log_file) {
                     value: linear_interp(value, time, MAG_Data[i].time),
                     type: 2,
                     name: name,
-                    tip: { text: "Fits with motor compensation from " + name + ". Ensure battery monitor is calibrated and functioning correctly."},
+                    tip: { text: "Calibrations with motor compensation from " + name + ". Ensure battery monitor is calibrated and functioning correctly."},
                     offsets: {},
                     scale: {},
                     iron: {}
@@ -2141,7 +2141,7 @@ function load(log_file) {
 
         let cal_legend = document.createElement("legend")
         cal_legend.innerHTML = "Calibrations"
-        add_tip(cal_legend, 'Select calibrations to be shown on plots, the last calibration selected will be saved when "Save Parameters" is clicked')
+        add_tip(cal_legend, 'Select calibrations to be shown on plots, the last calibration selected will be saved when "Save Parameters" is clicked.')
         cal_fieldset.appendChild(cal_legend)
 
 


### PR DESCRIPTION
Some fixes from https://github.com/ArduPilot/WebTools/issues/120

This removes "predicted" from the intro instead using "expected" inline with the rest of the tool. "fit" is replaced with "calibration" throughout.

A note is added to the no motor comp tool tip to give a clue about any grayed out options.

![image](https://github.com/ArduPilot/WebTools/assets/33176108/6fe937af-1218-41f0-885a-10ab88800b83)
