### PR TITLE
FilterReview: allow to work without IMU message for gyro rate

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -2796,8 +2796,8 @@ function load(log_file) {
     log.processData(log_file, [])
 
 
-    if (!("PARM" in log.messageTypes) || !("IMU" in log.messageTypes)) {
-        alert("No params or IMU in log")
+    if (!("PARM" in log.messageTypes)) {
+        alert("No params in log")
         return
     }
     const PARM = log.get("PARM")
@@ -2814,7 +2814,7 @@ function load(log_file) {
         if ((ID != null) && (ID > 0)) {
             const decoded = decode_devid(ID, DEVICE_TYPE_IMU)
 
-            if (i in log.messageTypes.IMU.instances) {
+            if (("IMU" in log.messageTypes) && (i in log.messageTypes.IMU.instances)) {
                 // Assume constant rate, this is not actually true, but variable rate breaks FFT averaging.
                 gyro_rate[i] = array_mean(log.get_instance("IMU", i, "GHz"))
             }


### PR DESCRIPTION
This removes the requirement to have `IMU` in the log. if available it is used to get the gyro rate. 