### PR TITLE
FilterReview: fix ESC indexing

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -175,12 +175,10 @@ class ESCTarget extends NotchTarget {
 
         // Individual RPM
         var instances = 0
-        var instance_map = []
         for (const inst of Object.keys(log.messageTypes[msg].instances)) {
             this.data[instances] = {}
             this.data[instances].time = TimeUS_to_seconds(log.get_instance(msg, inst, "TimeUS"))
             this.data[instances].freq = array_scale(log.get_instance(msg, inst, "RPM"), 1 / 60)
-            instance_map[parseFloat(inst)] = instances
             instances++
         }
 
@@ -203,7 +201,7 @@ class ESCTarget extends NotchTarget {
         const len = all.length
         for (let i=0;i<len;i++) {
             // Update instance
-            const instance = instance_map[all[i].inst]
+            const instance = all[i].inst
             inst[instance].freq = all[i].freq
             inst[instance].time_ms = all[i].time
 


### PR DESCRIPTION
Fix for https://github.com/ArduPilot/WebTools/issues/130, the log had ESC's 1,2,3,4 rather than 0,1,2,3 so the indexing got messed up. Seems like we don't need the `instance_map`, we don't ever display ESC numbers, so it doesn't really matter if they don't match the log. 