### PR TITLE
Hardware Report: treat board ID of 0 as invalid

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1937,7 +1937,9 @@ function load_log(log_file) {
         // Assume version does not change, just use first msg
         const fw_string = VER.FWS[0]
         const hash = VER.GH[0].toString(16)
-        board_id = VER.APJ[0]
+        if (VER.APJ[0] != 0) {
+            board_id = VER.APJ[0]
+        }
 
         let section = document.getElementById("VER")
         section.hidden = false


### PR DESCRIPTION
Currently on linux boards we show the flight controller section with nothing in it because 0 is the default value. 

![image](https://github.com/ArduPilot/WebTools/assets/33176108/652fdf2c-79ec-48c4-b198-afe2a569d11e)

This treats 0 as invalid so that section is not shown unless a flight controller string can be parsed from messages.