### PR TITLE
all: make param nicer strings and sort param downloads alphabetically

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -2475,7 +2475,7 @@ function save_parameters() {
             var name = "" + inputs[v].id;
             if (name.startsWith("INS_")) {
                 var value = inputs[v].value;
-                params += name + "," + value + "\n";
+                params += name + "," + param_to_string(value) + "\n";
             }
         }
         return params

--- a/FilterTool/filters.js
+++ b/FilterTool/filters.js
@@ -920,7 +920,7 @@ function save_parameters() {
             var name = "" + inputs[v].id;
             if (name.startsWith("INS_")) {
                 var value = inputs[v].value;
-                params += name + "," + value + "\n";
+                params += name + "," + param_to_string(value) + "\n";
             }
         }
         return params

--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -2896,12 +2896,7 @@ function save_all_parameters() {
         return
     }
 
-    let text = ""
-    for (const [name, value] of Object.entries(params)) {
-        text += name + "," + value + "\n";
-    }
-
-    save_text(text, ".param")
+    save_text(get_param_download_text(params), ".param")
 
 }
 
@@ -2911,15 +2906,15 @@ function save_changed_parameters() {
         return
     }
 
-    let text = ""
+    let changed = {}
     for (const [name, value] of Object.entries(params)) {
         if ((name in defaults) && (value == defaults[name])) {
             continue
         }
-        text += name + "," + value + "\n";
+        changed[name] = value
     }
 
-    save_text(text, "_changed.param")
+    save_text(get_param_download_text(changed), "_changed.param")
 
 }
 
@@ -2946,7 +2941,7 @@ function save_minimal_parameters() {
         }
     }
 
-    let text = ""
+    let minimal = {}
     for (const [name, value] of Object.entries(params)) {
         if (changed && (name in defaults) && (value == defaults[name])) {
             continue
@@ -2954,10 +2949,10 @@ function save_minimal_parameters() {
         if (skip_params.includes(name)) {
             continue
         }
-        text += name + "," + value + "\n";
+        minimal[name] = value
     }
 
-    save_text(text, "_minimal.param")
+    save_text(get_param_download_text(minimal), "_minimal.param")
 
 }
 

--- a/Libraries/Param_Helpers.js
+++ b/Libraries/Param_Helpers.js
@@ -63,3 +63,43 @@ function get_param_value(param_log, name, allow_change) {
     return value
 }
 
+// Return a string for a given param value
+function param_to_string(value)
+{
+    // Make sure number can be represented by 32 bit float
+    const float_val = Math.fround(value)
+
+    const significant_figures = [7,8,9]
+    for (figures of significant_figures) {
+        // Convert to a string with the given number of figures
+        // This gives the value we want, but with trailing zeros
+        const string_val = float_val.toPrecision(figures)
+
+        // Go back to number
+        const number_val = Number(string_val)
+        if (float_val != Math.fround(number_val)) {
+            // Did not get original value, try more digits
+            continue
+        }
+
+        // Convert number back to string with no trailing zeros
+        return number_val.toString()
+    }
+
+    throw new Error("Could not convert " + value.toString() + " to float string")
+}
+
+// Return formatted text for param download
+function get_param_download_text(params)
+{
+    // Sort alphabetically, localeCompare does underscores differently to built in sort
+    const keys = Object.keys(params).sort((a, b) =>
+        a.localeCompare(b)
+    )
+
+    let text = ""
+    for (const key of keys) {
+        text += key + "," + param_to_string(params[key]) + "\n";
+    }
+    return text
+}

--- a/LogFinder/LogFinder.js
+++ b/LogFinder/LogFinder.js
@@ -160,12 +160,10 @@ function setup_table(logs) {
                     return
                 }
 
-                let text = ""
-                for (const [name, value] of Object.entries(params)) {
-                    text += name + "," + value + "\n";
-                }
+                // Get contents of file to download
+                const text = get_param_download_text(params)
 
-                // make sure there are no slashes
+                // make sure there are no slashes in file name
                 let log_file_name = log.info.name.replace(/.*[\/\\]/, '')
 
                 // Replace the file extension
@@ -256,7 +254,7 @@ function setup_table(logs) {
                     details.appendChild(summary)
 
                     for (const [name, value] of Object.entries(added)) {
-                        const text = name + ": " + value.toString()
+                        const text = name + ": " + param_to_string(value)
                         details.appendChild(document.createTextNode(text))
                         details.appendChild(document.createElement("br"))
                     }
@@ -273,7 +271,7 @@ function setup_table(logs) {
                     details.appendChild(summary)
 
                     for (const [name, value] of Object.entries(missing)) {
-                        const text = name + ": " + value.toString()
+                        const text = name + ": " + param_to_string(value)
                         details.appendChild(document.createTextNode(text))
                         details.appendChild(document.createElement("br"))
                     }
@@ -290,7 +288,7 @@ function setup_table(logs) {
                     details.appendChild(summary)
 
                     for (const [name, values] of Object.entries(changed)) {
-                        const text = name + ": " + values.from.toString() + " => " + values.to.toString()
+                        const text = name + ": " + param_to_string(values.from) + " => " + param_to_string(values.to)
                         details.appendChild(document.createTextNode(text))
                         details.appendChild(document.createElement("br"))
                     }

--- a/LogFinder/index.html
+++ b/LogFinder/index.html
@@ -7,6 +7,7 @@
 <script type="text/javascript" src="../Libraries/FileSaver.js"></script>
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
+<script type="text/javascript" src="../Libraries/Param_Helpers.js"></script>
 
 <link href="https://unpkg.com/tabulator-tables@6.2.0/dist/css/tabulator.min.css" rel="stylesheet">
 <script src="https://unpkg.com/luxon@3.4.4/build/global/luxon.min.js"></script>

--- a/MAGFit/magfit.js
+++ b/MAGFit/magfit.js
@@ -235,7 +235,7 @@ const scale_range = [0.8, 1.2]
 function save_parameters() {
 
     function param_string(name, value) {
-        return name + "," + value + "\n"
+        return name + "," + param_to_string(value) + "\n"
     }
     
     function save_params(names, values) {


### PR DESCRIPTION
JavaScript does not have floats, so all param values are stored as floats, since some numbers are not representable exactly we sometimes get mad values that could not be represented by a float. EG:
![image](https://github.com/ArduPilot/WebTools/assets/33176108/682966ad-b75b-4f44-a222-f0b198e160cc)

We now get much more sensible numbers:
![image](https://github.com/ArduPilot/WebTools/assets/33176108/6ad41c35-19f6-48b5-bc49-63a130ede0df)
 
This also changes to sort any param download files alphabetically, this makes them easyer to diff against one another and param files from mission planner. 