### PR TITLE
HardwareReport: check for log is not null before trying to find GPS type from messages.

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1207,7 +1207,7 @@ function load_gps(log) {
         }
     }
 
-    if ('MSG' in log.messageTypes) {
+    if ((log != null) && ('MSG' in log.messageTypes)) {
         const messages = log.get("MSG").Message
 
         // This regular expression is used to get the word after "as" to get the GPS device name.


### PR DESCRIPTION
A little fixup for https://github.com/ArduPilot/WebTools/pull/133.