### PR TITLE
Hardwarereport: add UART and DroneCAN data rate plots

### DIFF
--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -262,6 +262,9 @@
   <div id="performance_time" style="width:800px;height:400px"></div>
 </div>
 
+<h3 hidden>Data Rates</h3>
+<p id="DataRates"></p>
+
 <h3 id="Stack" hidden>Stack</h3>
 <div hidden>
   <h4>Free memory</h4>


### PR DESCRIPTION
This adds plots showing the UART data rates (logging is only in master):
![image](https://github.com/ArduPilot/WebTools/assets/33176108/1def607e-4d88-4ae0-ab78-b025da846e32)

It also adds DroneCAN frame rates:
![image](https://github.com/ArduPilot/WebTools/assets/33176108/1123d774-b3c4-4d8a-8345-b7ff39254223)

It would be nice to also plot a limit value based on the bit rate, but its complicated to go from a bit rate to a frame rate. 