### PR TITLE
Libraries: decode devid: add BMP581

### DIFF
--- a/Libraries/DecodeDevID.js
+++ b/Libraries/DecodeDevID.js
@@ -105,6 +105,7 @@ baro_types = {
     0x12 : "MS5837",
     0x13 : "MS5637",
     0x14 : "BMP390",
+    0x15 : "BMP581",
 }
 
 airspeed_types = {


### PR DESCRIPTION
As mentioned in this PR https://github.com/ArduPilot/ardupilot/pull/27249 . Add BMP581 to baro type of DecodeDevID.