### PR TITLE
Add helper to get firmware and board version details from a log

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -2338,64 +2338,39 @@ async function load_log(log_file) {
 
     load_params(log)
 
-    let flight_controller = null
-    let board_id = null
+    const version = get_version_and_board(log)
 
-    if ('VER' in log.messageTypes) {
-        const VER = log.get("VER")
-
-        // Assume version does not change, just use first msg
-        const fw_string = VER.FWS[0]
-        const hash = VER.GH[0].toString(16)
-        if (VER.APJ[0] != 0) {
-            board_id = VER.APJ[0]
-        }
-
+    if (version.fw_string != null) {
         let section = document.getElementById("VER")
         section.hidden = false
         section.previousElementSibling.hidden = false
-        section.appendChild(document.createTextNode(fw_string))
+        section.appendChild(document.createTextNode(version.fw_string))
 
-        if ('MSG' in log.messageTypes) {
-            const MSG = log.get("MSG")
-            // Look for firmware string in MSGs, this marks the start of the log start msgs
-            // The subsequent messages give more info, this is a bad way of doing it
-            const len = MSG.Message.length
-            for (let i = 0; i < MSG.Message.length - 3; i++) {
-                const msg = MSG.Message[i]
-                if (fw_string != msg) {
-                    continue
-                }
-                if (!MSG.Message[i+3].startsWith("Param space used:")) {
-                    // Check we have bracketed the messages we need
-                    continue
-                }
-                section.appendChild(document.createElement("br"))
-                section.appendChild(document.createTextNode(MSG.Message[i+1]))
-                flight_controller = MSG.Message[i+2]
-                break
-            }
+        if (version.os_string != null) {
+            section.appendChild(document.createElement("br"))
+            section.appendChild(document.createTextNode(version.os_string))
         }
 
-        check_release(hash, section)
+        if (version.fw_hash != null) {
+            check_release(version.fw_hash, section)
+        }
     }
 
-
-    if ((flight_controller != null) || (board_id != null)) {
+    if ((version.flight_controller != null) || (version.board_id != null)) {
         let section = document.getElementById("FC")
         section.hidden = false
         section.previousElementSibling.hidden = false
-        if (flight_controller != null) {
+        if (version.flight_controller != null) {
             // Print name given in log
-            section.appendChild(document.createTextNode(flight_controller))
+            section.appendChild(document.createTextNode(version.flight_controller))
         }
-        if (board_id != null) {
+        if (version.board_id != null) {
             // Lookup the board ID
             section.appendChild(document.createElement("br"))
             section.appendChild(document.createElement("br"))
-            section.appendChild(document.createTextNode("Board ID: " + board_id))
-            if (board_id in board_types) {
-                section.appendChild(document.createTextNode(" " + board_types[board_id]))
+            section.appendChild(document.createTextNode("Board ID: " + version.board_id))
+            if (version.board_id in board_types) {
+                section.appendChild(document.createTextNode(" " + board_types[version.board_id]))
             }
         }
     }

--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -11,6 +11,7 @@
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/Param_Helpers.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 
 <script src='../modules/plotly.js/dist/plotly.min.js'></script>
 

--- a/Libraries/LogHelpers.js
+++ b/Libraries/LogHelpers.js
@@ -1,0 +1,82 @@
+// Useful functions that are used by multiple tools
+
+// Get firmware version and board details
+function get_version_and_board(log) {
+
+    let flight_controller
+    let board_id
+    let fw_string
+    let fw_hash
+    let os_string
+    let build_type
+    let filter_version
+
+    if ('VER' in log.messageTypes) {
+        const VER = log.get("VER")
+
+        // Assume version does not change, just use first msg
+        fw_string = VER.FWS[0]
+        fw_hash = VER.GH[0].toString(16)
+        if (VER.APJ[0] != 0) {
+            board_id = VER.APJ[0]
+        }
+        if ("BU" in VER) {
+            build_type = VER.BU[0]
+        }
+        if ("FV" in VER) {
+            filter_version = VER.FV[0]
+        }
+    }
+
+    if ('MSG' in log.messageTypes) {
+        const MSG = log.get("MSG")
+        // Look for firmware string in MSGs, this marks the start of the log start msgs
+        // The subsequent messages give more info, this is a bad way of doing it
+        const len = MSG.Message.length
+        for (let i = 0; i < len - 3; i++) {
+            const msg = MSG.Message[i]
+            if ((fw_string != null) && (fw_string != msg)) {
+                continue
+            }
+            if (!MSG.Message[i+3].startsWith("Param space used:")) {
+                // Check we have bracketed the messages we need
+                continue
+            }
+            if (fw_string == null) {
+                const build_types = {
+                    ArduRover: 1,
+                    ArduCopter: 2,
+                    ArduPlane: 3,
+                    AntennaTracker: 4,
+                    ArduSub: 7,
+                    Blimp: 12,
+                }
+                let types = []
+                for (const type of Object.keys(build_types)) {
+                    types.push("(?:" + type + ")")
+                }
+                const regex = new RegExp("(" + types.join("|") + ").+\\((.+)\\)", 'g')
+                const found = regex.exec(MSG.Message[i])
+                if (found == null) {
+                    continue
+                }
+                fw_string = found[0]
+                build_type = build_types[found[1]]
+                fw_hash = found[2]
+            }
+            os_string = MSG.Message[i+1]
+            flight_controller = MSG.Message[i+2]
+            break
+        }
+    }
+
+    return {
+        flight_controller,
+        board_id,
+        fw_string,
+        fw_hash,
+        os_string,
+        build_type,
+        filter_version
+    }
+}

--- a/LogFinder/index.html
+++ b/LogFinder/index.html
@@ -9,6 +9,7 @@
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script type="text/javascript" src="../Libraries/Param_Helpers.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 
 <link href="../modules/tabulator/dist/css/tabulator.min.css" rel="stylesheet">
 <script src="../modules/build/luxon/build/global/luxon.min.js"></script>


### PR DESCRIPTION
This adds a helper to get version and board details to both hardware report and log finder. This allows hardware report to extract the version from older logs. 