### PR TITLE
All: only allow open in in tools that might work with the given log

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -2805,6 +2805,7 @@ async function load(log_file) {
     let log = new DataflashParser()
     log.processData(log_file, [])
 
+    open_in_update(log)
 
     if (!("PARM" in log.messageTypes)) {
         alert("No params in log")

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -20,6 +20,7 @@
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/Plotly_helpers.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 
 </head>
 <table style="width:1200px"><tr><td>
@@ -688,7 +689,7 @@ These params can then be saved and loaded into the autopilot without the need fo
         reader.readAsArrayBuffer(file)
     }
 
-    setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
+    const open_in_update = setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
 
     init_loading_overlay()
 

--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -2371,6 +2371,8 @@ async function load_log(log_file) {
     let log = new DataflashParser()
     log.processData(log_file, [])
 
+    open_in_update(log)
+
     if (!('PARM' in log.messageTypes)) {
         // The whole tool assumes it has param values
         alert("No parameter values found in log")

--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -315,7 +315,7 @@
     throw new Error(e.reason.stack)
   })
 
-  setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { reset(); load_log(data) }) }, "right")
+  const open_in_update = setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { reset(); load_log(data) }) }, "right")
 
   init_loading_overlay()
 

--- a/Libraries/LogHelpers.js
+++ b/Libraries/LogHelpers.js
@@ -80,3 +80,17 @@ function get_version_and_board(log) {
         filter_version
     }
 }
+
+// Take all log and return array of available base message types (no instances)
+function get_base_log_message_types(log) {
+    let all_types = Object.keys(log.messageTypes)
+    let base_types = []
+    for (const type of all_types) {
+        if (/.+\[.+\]/gm.test(type) ) {
+            // Discard instance messages
+            continue
+        }
+        base_types.push(type)
+    }
+    return base_types
+}

--- a/LogFinder/LogFinder.js
+++ b/LogFinder/LogFinder.js
@@ -219,8 +219,12 @@ function setup_table(logs) {
                 return cell.getRow().getData().fileHandle
             }
 
+            const open_in = get_open_in(get_file_fun)
+            open_in.update_enable(cell.getRow().getData().info.available_log_messages)
+
+
             tippy(button, {
-                content: open_in_tippy_div(get_file_fun),
+                content: open_in.tippy_div,
                 placement: 'left',
                 interactive: true,
                 appendTo: () => document.body,
@@ -725,7 +729,8 @@ function load_log(log_file) {
         flight_time,
         watchdog,
         crash_dump,
-        distance_traveled
+        distance_traveled,
+        available_log_messages: get_base_log_message_types(log),
     }
 }
 

--- a/MAGFit/index.html
+++ b/MAGFit/index.html
@@ -21,6 +21,7 @@
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/DecodeDevID.js"></script>
 <script type="text/javascript" src="../Libraries/FileSaver.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 <script type="text/javascript" src="magfit.js"></script>
 
 </head>
@@ -396,7 +397,7 @@ For best results use a flight log that covers as many orientations as possible. 
         reader.readAsArrayBuffer(file)
     }
 
-    setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
+    const open_in_update = setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
 
     init_loading_overlay()
 

--- a/MAGFit/magfit.js
+++ b/MAGFit/magfit.js
@@ -1688,6 +1688,8 @@ async function load(log_file) {
     let log = new DataflashParser()
     log.processData(log_file, [])
 
+    open_in_update(log)
+
     if (!("MAG" in log.messageTypes) || !("instances" in log.messageTypes.MAG)) {
         alert("No compass data in log")
         return

--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -1472,6 +1472,8 @@ async function load(log_file) {
     let log = new DataflashParser()
     log.processData(log_file , [])
 
+    open_in_update(log)
+
     // micro seconds to seconds helpers
     const US2S = 1 / 1000000
     function TimeUS_to_seconds(TimeUS) {

--- a/PIDReview/index.html
+++ b/PIDReview/index.html
@@ -12,6 +12,7 @@
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/Plotly_helpers.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 
 <script src="../modules/build/floating-ui/dist/umd/popper.min.js"></script>
 <script src="../modules/build/tippyjs/dist/tippy-bundle.umd.min.js"></script>
@@ -292,7 +293,7 @@
         reader.readAsArrayBuffer(file)
     }
 
-    setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
+    const open_in_update = setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { load(data) }) })
 
     init_loading_overlay()
 

--- a/StreamStats/StreamStats.js
+++ b/StreamStats/StreamStats.js
@@ -100,6 +100,8 @@ function load_log(log_file) {
     log = new DataflashParser()
     log.processData(log_file, [])
 
+    open_in_update(log)
+
     plot_log()
 
     const end = performance.now()

--- a/StreamStats/index.html
+++ b/StreamStats/index.html
@@ -11,6 +11,7 @@
 <script type="text/javascript" src="../Libraries/OpenIn.js"></script>
 <script type="text/javascript" src="../Libraries/LoadingOverlay.js"></script>
 <script type="text/javascript" src="../Libraries/Plotly_helpers.js"></script>
+<script type="text/javascript" src="../Libraries/LogHelpers.js"></script>
 
 <script src='../modules/plotly.js/dist/plotly.min.js'></script>
 
@@ -115,7 +116,7 @@
   tippy('#TT')
 
 
-  setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { reset(); load_log(data) }) }, "right")
+  const open_in_update = setup_open_in("OpenIn", "fileItem", function (data) { loading_call(() => { reset(); load_log(data) }) }, "right")
 
   init_loading_overlay()
 


### PR DESCRIPTION
This adds a basic check that the required messages are present in a log before the open in button is enabled for a given log. 

For example if a log does not have `GYR` or `ISBD` then opening in filter review will not work. Currently you can click it only to get:
![image](https://github.com/user-attachments/assets/f8add099-4696-446f-bce7-360fcd6db97c)

Now that option will be disabled for that log:
![image](https://github.com/user-attachments/assets/82ca2c85-bcc5-4dcc-8452-e4a83c96e44d)

This is only a basic check, it does not check that there is enough data for the tool to work well for example. 

For LogFinder this does mean we store the list of messages for each log, so it will use a more memory. We could re-open the log on hover over like we do for the map, but this is much slower. If we were to do the per tool check at first we could only store a true/false for each tool which would save on memory but result in the logic being in a bit of a odd place.