### PR TITLE
FilterReview: Rawlogging: remove instance if no valid data is found

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -2754,6 +2754,12 @@ function load_from_raw_log(log, num_gyro, gyro_rate, get_param) {
 
         }
 
+        if (Gyro_batch[i].length == 0) {
+            // No valid batches, remove
+            delete Gyro_batch[i]
+            continue
+        }
+
         // Assume a constant sample rate for the FFT
         const sample_rate = sample_rate_sum / sample_rate_count
         Gyro_batch[i].gyro_rate = sample_rate


### PR DESCRIPTION
With the new log primary only options a rapid EKF land switch can result in a sensor only being primary momentarily. If that is not long enough to be considered a valid batch then the tool falls over because its not expecting a sensor instance with no data. This just deletes the instance in that case. 