### PR TITLE
FilterReview: add support for new version of AP notch logging

### DIFF
--- a/FilterReview/FilterReview.js
+++ b/FilterReview/FilterReview.js
@@ -153,6 +153,15 @@ class RPMTarget extends NotchTarget {
             if (inst in Object.keys(log.messageTypes.RPM.instances)) {
                 this.data.time = TimeUS_to_seconds(log.get_instance(msg_name, inst, "TimeUS"))
                 this.data.value = log.get_instance(msg_name, inst, "RPM")
+
+                // Set RPM to -1 when unhealthy, this maintains behavior with the old logging
+                const health = log.get_instance(msg_name, inst, "H")
+                const len = health.length
+                for (let i = 0; i < len; i++) {
+                    if (health[i] == 0) {
+                        this.data.value[i] = -1
+                    }
+                }
             }
 
         } else {

--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -101,7 +101,7 @@ These params can then be saved and loaded into the autopilot without the need fo
                 </fieldset>
             </td>
             <td>
-                <fieldset style="width:200px;height:80px">
+                <fieldset style="width:125px;height:80px">
                     <legend>Analysis time
                         <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
                         data-tippy-content='Start and end times for averaging of FFT results show in the IMU Spectrum plot, automatically updated from the selected portion of the log shown in the Flight Data plot. The Calculate button must be clicked after any change of start/end time.'
@@ -111,6 +111,19 @@ These params can then be saved and loaded into the autopilot without the need fo
                     <input id="TimeStart" name="TimeStart" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:50px"/><br><br>
                     <label for="TimeEnd">End (s)</label>
                     <input id="TimeEnd" name="TimeEnd" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:50px"/>
+                </fieldset>
+            </td>
+            <td>
+                <fieldset style="width:110px;height:80px">
+                    <legend>Filter version
+                        <img id="TT" src="../images/question-circle.svg" style="width: 1em; vertical-align: bottom" 
+                        data-tippy-content='ArduPilot version 4.6 and newer have a updated strategy at frequencies lower then the configured min frequency. The version is automatically populated from the log but can be manually changed to check how the new strategy would work using a log from a older version.'
+                        data-tippy-maxWidth='750px'/>
+                    </legend>
+                    <input type="radio" id="filter_version_1" name="filter_version" onchange="loading_call(re_calc)">
+                    <label for="filter_version_1">1.0</label><br>
+                    <input type="radio" id="filter_version_2" name="filter_version" onchange="loading_call(re_calc)">
+                    <label for="filter_version_2">2.0</label><br>
                 </fieldset>
             </td>
             <td style="width: 10px;"></td>

--- a/FilterReview/params.json
+++ b/FilterReview/params.json
@@ -16,8 +16,7 @@
         "162000": "Fast",
         "30000": "VerySlow",
         "72000": "Slow"
-      },
-      "__field_text": "\n    // @DisplayName: Acceleration Max for Pitch\n    // @Description: Maximum acceleration in pitch axis\n    // @Units: cdeg/s/s\n    // @Range: 0 180000\n    // @Increment: 1000\n    // @Values: 0:Disabled, 30000:VerySlow, 72000:Slow, 108000:Medium, 162000:Fast\n    // @User: Advanced"
+      }
     },
     "ATC_ACCEL_R_MAX": {
       "Description": "Maximum acceleration in roll axis",
@@ -35,8 +34,7 @@
         "162000": "Fast",
         "30000": "VerySlow",
         "72000": "Slow"
-      },
-      "__field_text": "\n    // @DisplayName: Acceleration Max for Roll\n    // @Description: Maximum acceleration in roll axis\n    // @Units: cdeg/s/s\n    // @Range: 0 180000\n    // @Increment: 1000\n    // @Values: 0:Disabled, 30000:VerySlow, 72000:Slow, 108000:Medium, 162000:Fast\n    // @User: Advanced"
+      }
     },
     "ATC_ACCEL_Y_MAX": {
       "Description": "Maximum acceleration in yaw axis",
@@ -54,8 +52,7 @@
         "36000": "Medium",
         "54000": "Fast",
         "9000": "VerySlow"
-      },
-      "__field_text": "\n    // @DisplayName: Acceleration Max for Yaw\n    // @Description: Maximum acceleration in yaw axis\n    // @Units: cdeg/s/s\n    // @Range: 0 72000\n    // @Values: 0:Disabled, 9000:VerySlow, 18000:Slow, 36000:Medium, 54000:Fast\n    // @Increment: 1000\n    // @User: Advanced"
+      }
     },
     "ATC_ANGLE_BOOST": {
       "Description": "Angle Boost increases output throttle as the vehicle leans to reduce loss of altitude",
@@ -64,8 +61,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Angle Boost\n    // @Description: Angle Boost increases output throttle as the vehicle leans to reduce loss of altitude\n    // @Values: 0:Disabled, 1:Enabled\n    // @User: Advanced"
+      }
     },
     "ATC_ANG_LIM_TC": {
       "Description": "Angle Limit (to maintain altitude) Time Constant",
@@ -74,8 +70,7 @@
         "high": "10.0",
         "low": "0.5"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Angle Limit (to maintain altitude) Time Constant\n    // @Description: Angle Limit (to maintain altitude) Time Constant\n    // @Range: 0.5 10.0\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_ANG_PIT_P": {
       "Description": "Pitch axis angle controller P gain.  Converts the error between the desired pitch angle and actual angle to a desired pitch rate",
@@ -84,8 +79,7 @@
         "high": "12.000",
         "low": "3.000"
       },
-      "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis angle controller P gain\n    // @Description: Pitch axis angle controller P gain.  Converts the error between the desired pitch angle and actual angle to a desired pitch rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 12.000\n    // @User: Standard"
+      "User": "Standard"
     },
     "ATC_ANG_RLL_P": {
       "Description": "Roll axis angle controller P gain.  Converts the error between the desired roll angle and actual angle to a desired roll rate",
@@ -94,8 +88,7 @@
         "high": "12.000",
         "low": "3.000"
       },
-      "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis angle controller P gain\n    // @Description: Roll axis angle controller P gain.  Converts the error between the desired roll angle and actual angle to a desired roll rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 12.000\n    // @User: Standard"
+      "User": "Standard"
     },
     "ATC_ANG_YAW_P": {
       "Description": "Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate",
@@ -104,8 +97,7 @@
         "high": "12.000",
         "low": "3.000"
       },
-      "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis angle controller P gain\n    // @Description: Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 6.000\n    // @User: Standard"
+      "User": "Standard"
     },
     "ATC_HOVR_ROL_TRM": {
       "Description": "Trim the hover roll angle to counter tail rotor thrust in a hover",
@@ -116,8 +108,7 @@
         "low": "0"
       },
       "Units": "cdeg",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Hover Roll Trim\n    // @Description: Trim the hover roll angle to counter tail rotor thrust in a hover\n    // @Units: cdeg\n    // @Increment: 10\n    // @Range: 0 1000\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_INPUT_TC": {
       "Description": "Attitude control input time constant.  Low numbers lead to sharper response, higher numbers to softer response",
@@ -135,8 +126,34 @@
         "0.15": "Medium",
         "0.2": "Soft",
         "0.5": "Very Soft"
+      }
+    },
+    "ATC_LAND_P_MULT": {
+      "Description": "Pitch gain multiplier active when landed. A factor of 1.0 means no reduction in gain while landed. Reduce this factor to reduce ground oscitation in the pitch axis. ",
+      "DisplayName": "Landed pitch gain multiplier",
+      "Range": {
+        "high": "1.0",
+        "low": "0.25"
       },
-      "__field_text": "\n    // @DisplayName: Attitude control input time constant\n    // @Description: Attitude control input time constant.  Low numbers lead to sharper response, higher numbers to softer response\n    // @Units: s\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @Values: 0.5:Very Soft, 0.2:Soft, 0.15:Medium, 0.1:Crisp, 0.05:Very Crisp\n    // @User: Standard"
+      "User": "Advanced"
+    },
+    "ATC_LAND_R_MULT": {
+      "Description": "Roll gain multiplier active when landed. A factor of 1.0 means no reduction in gain while landed. Reduce this factor to reduce ground oscitation in the roll axis. ",
+      "DisplayName": "Landed roll gain multiplier",
+      "Range": {
+        "high": "1.0",
+        "low": "0.25"
+      },
+      "User": "Advanced"
+    },
+    "ATC_LAND_Y_MULT": {
+      "Description": "Yaw gain multiplier active when landed. A factor of 1.0 means no reduction in gain while landed. Reduce this factor to reduce ground oscitation in the yaw axis. ",
+      "DisplayName": "Landed yaw gain multiplier",
+      "Range": {
+        "high": "1.0",
+        "low": "0.25"
+      },
+      "User": "Advanced"
     },
     "ATC_PIRO_COMP": {
       "Description": "Pirouette compensation enabled",
@@ -145,18 +162,16 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Piro Comp Enable\n    // @Description: Pirouette compensation enabled\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     },
     "ATC_RATE_FF_ENAB": {
-      "Description": "Controls whether body-frame rate feedfoward is enabled or disabled",
+      "Description": "Controls whether body-frame rate feedforward is enabled or disabled",
       "DisplayName": "Rate Feedforward Enable",
       "User": "Advanced",
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Rate Feedforward Enable\n    // @Description: Controls whether body-frame rate feedfoward is enabled or disabled\n    // @Values: 0:Disabled, 1:Enabled\n    // @User: Advanced"
+      }
     },
     "ATC_RATE_P_MAX": {
       "Description": "Maximum angular velocity in pitch axis",
@@ -173,8 +188,7 @@
         "180": "Medium",
         "360": "Fast",
         "60": "Slow"
-      },
-      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Pitch\n    // @Description: Maximum angular velocity in pitch axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+      }
     },
     "ATC_RATE_R_MAX": {
       "Description": "Maximum angular velocity in roll axis",
@@ -191,8 +205,7 @@
         "180": "Medium",
         "360": "Fast",
         "60": "Slow"
-      },
-      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Roll\n    // @Description: Maximum angular velocity in roll axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+      }
     },
     "ATC_RATE_Y_MAX": {
       "Description": "Maximum angular velocity in yaw axis",
@@ -209,8 +222,7 @@
         "180": "Medium",
         "360": "Fast",
         "60": "Slow"
-      },
-      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Yaw\n    // @Description: Maximum angular velocity in yaw axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+      }
     },
     "ATC_RAT_PIT_D": {
       "Description": "Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate",
@@ -221,7 +233,17 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller D gain\n    // @Description: Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_PIT_D_FF": {
+      "Description": "FF D Gain which produces an output that is proportional to the rate of change of the target",
+      "DisplayName": "Pitch Derivative FeedForward Gain",
+      "Increment": "0.0001",
+      "Range": {
+        "high": "0.02",
+        "low": "0"
+      },
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_FF": {
@@ -233,7 +255,6 @@
         "low": "0.05"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller feed forward\n    // @Description: Pitch axis rate controller feed forward\n    // @Range: 0.05 0.5\n    // @Increment: 0.001\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_FLTD": {
@@ -246,7 +267,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller derivative frequency in Hz\n    // @Description: Pitch axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_FLTE": {
@@ -259,7 +279,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller error frequency in Hz\n    // @Description: Pitch axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_FLTT": {
@@ -272,7 +291,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller target frequency in Hz\n    // @Description: Pitch axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_I": {
@@ -284,7 +302,6 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I gain\n    // @Description: Pitch axis rate controller I gain.  Corrects long-term difference in desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.6\n    // @Increment: 0.01\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_ILMI": {
@@ -294,8 +311,7 @@
         "high": "1",
         "low": "0"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_RAT_PIT_IMAX": {
       "Description": "Pitch axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
@@ -306,7 +322,26 @@
         "low": "0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I gain maximum\n    // @Description: Pitch axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_PIT_NEF": {
+      "Description": "Pitch Error notch filter index",
+      "DisplayName": "Pitch Error notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_PIT_NTF": {
+      "Description": "Pitch Target notch filter index",
+      "DisplayName": "Pitch Target notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_PIT_P": {
@@ -318,8 +353,16 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Pitch axis rate controller P gain\n    // @Description: Pitch axis rate controller P gain.  Corrects in proportion to the difference between the desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.35\n    // @Increment: 0.005\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_PIT_PDMX": {
+      "Description": "Pitch axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output",
+      "DisplayName": "Pitch axis rate controller PD sum maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      }
     },
     "ATC_RAT_PIT_SMAX": {
       "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
@@ -330,7 +373,6 @@
         "low": "0"
       },
       "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Pitch slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_D": {
@@ -342,7 +384,17 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller D gain\n    // @Description: Roll axis rate controller D gain.  Compensates for short-term change in desired roll rate vs actual roll rate\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_RLL_D_FF": {
+      "Description": "FF D Gain which produces an output that is proportional to the rate of change of the target",
+      "DisplayName": "Roll Derivative FeedForward Gain",
+      "Increment": "0.0001",
+      "Range": {
+        "high": "0.02",
+        "low": "0"
+      },
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_FF": {
@@ -354,7 +406,6 @@
         "low": "0.05"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller feed forward\n    // @Description: Roll axis rate controller feed forward\n    // @Range: 0.05 0.5\n    // @Increment: 0.001\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_FLTD": {
@@ -367,7 +418,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller derivative frequency in Hz\n    // @Description: Roll axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_FLTE": {
@@ -380,7 +430,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller error frequency in Hz\n    // @Description: Roll axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_FLTT": {
@@ -393,7 +442,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller target frequency in Hz\n    // @Description: Roll axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_I": {
@@ -405,7 +453,6 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller I gain\n    // @Description: Roll axis rate controller I gain.  Corrects long-term difference in desired roll rate vs actual roll rate\n    // @Range: 0.0 0.6\n    // @Increment: 0.01\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_ILMI": {
@@ -415,8 +462,7 @@
         "high": "1",
         "low": "0"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_RAT_RLL_IMAX": {
       "Description": "Roll axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
@@ -427,7 +473,26 @@
         "low": "0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller I gain maximum\n    // @Description: Roll axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_RLL_NEF": {
+      "Description": "Roll Error notch filter index",
+      "DisplayName": "Roll Error notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_RLL_NTF": {
+      "Description": "Roll Target notch filter index",
+      "DisplayName": "Roll Target notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_RLL_P": {
@@ -439,8 +504,16 @@
         "low": "0.0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Roll axis rate controller P gain\n    // @Description: Roll axis rate controller P gain.  Corrects in proportion to the difference between the desired roll rate vs actual roll rate\n    // @Range: 0.0 0.35\n    // @Increment: 0.005\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_RLL_PDMX": {
+      "Description": "Roll axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output",
+      "DisplayName": "Roll axis rate controller PD sum maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      }
     },
     "ATC_RAT_RLL_SMAX": {
       "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
@@ -451,7 +524,6 @@
         "low": "0"
       },
       "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Roll slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_D": {
@@ -463,7 +535,17 @@
         "low": "0.000"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller D gain\n    // @Description: Yaw axis rate controller D gain.  Compensates for short-term change in desired yaw rate vs actual yaw rate\n    // @Range: 0.000 0.02\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_YAW_D_FF": {
+      "Description": "FF D Gain which produces an output that is proportional to the rate of change of the target",
+      "DisplayName": "Yaw Derivative FeedForward Gain",
+      "Increment": "0.0001",
+      "Range": {
+        "high": "0.02",
+        "low": "0"
+      },
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_FF": {
@@ -475,7 +557,6 @@
         "low": "0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller feed forward\n    // @Description: Yaw axis rate controller feed forward\n    // @Range: 0 0.5\n    // @Increment: 0.001\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_FLTD": {
@@ -488,7 +569,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller derivative frequency in Hz\n    // @Description: Yaw axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_FLTE": {
@@ -501,7 +581,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller error frequency in Hz\n    // @Description: Yaw axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_FLTT": {
@@ -514,7 +593,6 @@
       },
       "Units": "Hz",
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller target frequency in Hz\n    // @Description: Yaw axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_I": {
@@ -526,7 +604,6 @@
         "low": "0.01"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I gain\n    // @Description: Yaw axis rate controller I gain.  Corrects long-term difference in desired yaw rate vs actual yaw rate\n    // @Range: 0.01 0.2\n    // @Increment: 0.01\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_ILMI": {
@@ -536,8 +613,7 @@
         "high": "1",
         "low": "0"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_RAT_YAW_IMAX": {
       "Description": "Yaw axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
@@ -548,7 +624,27 @@
         "low": "0"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I gain maximum\n    // @Description: Yaw axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_YAW_NEF": {
+      "Description": "Yaw Error notch filter index",
+      "DisplayName": "Yaw Error notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_YAW_NTF": {
+      "Description": "Yaw Target notch filter index",
+      "DisplayName": "Yaw Target notch filter index",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "Units": "Hz",
+      "User": "Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_RAT_YAW_P": {
@@ -560,8 +656,16 @@
         "low": "0.180"
       },
       "User": "Standard",
-      "__field_text": "\n    // @DisplayName: Yaw axis rate controller P gain\n    // @Description: Yaw axis rate controller P gain.  Corrects in proportion to the difference between the desired yaw rate vs actual yaw rate\n    // @Range: 0.180 0.60\n    // @Increment: 0.005\n    // @User: Standard",
       "path": "AC_AttitudeControl_Heli"
+    },
+    "ATC_RAT_YAW_PDMX": {
+      "Description": "Yaw axis rate controller PD sum maximum.  The maximum/minimum value that the sum of the P and D term can output",
+      "DisplayName": "Yaw axis rate controller PD sum maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      }
     },
     "ATC_RAT_YAW_SMAX": {
       "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
@@ -572,11 +676,10 @@
         "low": "0"
       },
       "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Yaw slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
       "path": "AC_AttitudeControl_Heli"
     },
     "ATC_SLEW_YAW": {
-      "Description": "Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes",
+      "Description": "Maximum rate the yaw target can be updated in RTL and Auto flight modes",
       "DisplayName": "Yaw target slew rate",
       "Increment": "100",
       "Range": {
@@ -584,8 +687,7 @@
         "low": "500"
       },
       "Units": "cdeg/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Yaw target slew rate\n    // @Description: Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes\n    // @Units: cdeg/s\n    // @Range: 500 18000\n    // @Increment: 100\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_THR_G_BOOST": {
       "Description": "Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.",
@@ -594,8 +696,7 @@
         "high": "1",
         "low": "0"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle-gain boost\n    // @Description: Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.\n    // @Range: 0 1\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_THR_MIX_MAN": {
       "Description": "Throttle vs attitude control prioritisation used during manual flight (higher values mean we prioritise attitude control over throttle)",
@@ -604,8 +705,7 @@
         "high": "0.9",
         "low": "0.1"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle Mix Manual\n    // @Description: Throttle vs attitude control prioritisation used during manual flight (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.1 0.9\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_THR_MIX_MAX": {
       "Description": "Throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)",
@@ -614,8 +714,7 @@
         "high": "0.9",
         "low": "0.5"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle Mix Maximum\n    // @Description: Throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.5 0.9\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "ATC_THR_MIX_MIN": {
       "Description": "Throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)",
@@ -624,8 +723,7 @@
         "high": "0.25",
         "low": "0.1"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle Mix Minimum\n    // @Description: Throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.1 0.25\n    // @User: Advanced"
+      "User": "Advanced"
     }
   },
   "INS": {
@@ -634,8 +732,7 @@
       "Description": "Temperature that the 1st accelerometer was calibrated at",
       "DisplayName": "Calibration temperature for 1st accelerometer",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 1st accelerometer\n    // @Description: Temperature that the 1st accelerometer was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2OFFS_X": {
       "Calibration": "1",
@@ -646,8 +743,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 offsets of X axis\n    // @Description: Accelerometer2 offsets of X axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2OFFS_Y": {
       "Calibration": "1",
@@ -658,8 +754,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 offsets of Y axis\n    // @Description: Accelerometer2 offsets of Y axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2OFFS_Z": {
       "Calibration": "1",
@@ -670,8 +765,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 offsets of Z axis\n    // @Description: Accelerometer2 offsets of Z axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2SCAL_X": {
       "Calibration": "1",
@@ -681,8 +775,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 scaling of X axis\n    // @Description: Accelerometer2 scaling of X axis.  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2SCAL_Y": {
       "Calibration": "1",
@@ -692,8 +785,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 scaling of Y axis\n    // @Description: Accelerometer2 scaling of Y axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2SCAL_Z": {
       "Calibration": "1",
@@ -703,23 +795,20 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 scaling of Z axis\n    // @Description: Accelerometer2 scaling of Z axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the 2nd accelerometer was calibrated at",
       "DisplayName": "Calibration temperature for 2nd accelerometer",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 2nd accelerometer\n    // @Description: Temperature that the 2nd accelerometer was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC2_ID": {
       "Description": "Accelerometer2 sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Accelerometer2 ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer2 ID\n    // @Description: Accelerometer2 sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_ACC3OFFS_X": {
       "Calibration": "1",
@@ -730,8 +819,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 offsets of X axis\n    // @Description: Accelerometer3 offsets of X axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3OFFS_Y": {
       "Calibration": "1",
@@ -742,8 +830,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 offsets of Y axis\n    // @Description: Accelerometer3 offsets of Y axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3OFFS_Z": {
       "Calibration": "1",
@@ -754,8 +841,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 offsets of Z axis\n    // @Description: Accelerometer3 offsets of Z axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3SCAL_X": {
       "Calibration": "1",
@@ -765,8 +851,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 scaling of X axis\n    // @Description: Accelerometer3 scaling of X axis.  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3SCAL_Y": {
       "Calibration": "1",
@@ -776,8 +861,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 scaling of Y axis\n    // @Description: Accelerometer3 scaling of Y axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3SCAL_Z": {
       "Calibration": "1",
@@ -787,23 +871,20 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 scaling of Z axis\n    // @Description: Accelerometer3 scaling of Z axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the 3rd accelerometer was calibrated at",
       "DisplayName": "Calibration temperature for 3rd accelerometer",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 3rd accelerometer\n    // @Description: Temperature that the 3rd accelerometer was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC3_ID": {
       "Description": "Accelerometer3 sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Accelerometer3 ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer3 ID\n    // @Description: Accelerometer3 sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_ACCEL_FILTER": {
       "Description": "Filter cutoff frequency for accelerometers. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)",
@@ -813,8 +894,7 @@
         "low": "0"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accel filter cutoff frequency\n    // @Description: Filter cutoff frequency for accelerometers. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)\n    // @Units: Hz\n    // @Range: 0 256\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_ACCOFFS_X": {
       "Calibration": "1",
@@ -825,8 +905,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of X axis\n    // @Description: Accelerometer offsets of X axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACCOFFS_Y": {
       "Calibration": "1",
@@ -837,8 +916,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Y axis\n    // @Description: Accelerometer offsets of Y axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACCOFFS_Z": {
       "Calibration": "1",
@@ -849,8 +927,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Z axis\n    // @Description: Accelerometer offsets of Z axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACCSCAL_X": {
       "Calibration": "1",
@@ -860,8 +937,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of X axis\n    // @Description: Accelerometer scaling of X axis.  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACCSCAL_Y": {
       "Calibration": "1",
@@ -871,8 +947,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Y axis\n    // @Description: Accelerometer scaling of Y axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACCSCAL_Z": {
       "Calibration": "1",
@@ -882,8 +957,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Z axis\n    // @Description: Accelerometer scaling of Z axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_ACC_BODYFIX": {
       "Description": "The body-fixed accelerometer to be used for trim calculation",
@@ -893,15 +967,13 @@
         "1": "IMU 1",
         "2": "IMU 2",
         "3": "IMU 3"
-      },
-      "__field_text": "\n    // @DisplayName: Body-fixed accelerometer\n    // @Description: The body-fixed accelerometer to be used for trim calculation\n    // @User: Advanced\n    // @Values: 1:IMU 1,2:IMU 2,3:IMU 3"
+      }
     },
     "INS_ACC_ID": {
       "Description": "Accelerometer sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Accelerometer ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer ID\n    // @Description: Accelerometer sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_ENABLE_MASK": {
       "Bitmask": {
@@ -915,8 +987,7 @@
       },
       "Description": "Bitmask of IMUs to enable. It can be used to prevent startup of specific detected IMUs",
       "DisplayName": "IMU enable mask",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU enable mask\n    // @Description: Bitmask of IMUs to enable. It can be used to prevent startup of specific detected IMUs\n    // @User: Advanced\n    // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU,3:FourthIMU,4:FifthIMU,5:SixthIMU,6:SeventhIMU"
+      "User": "Advanced"
     },
     "INS_FAST_SAMPLE": {
       "Bitmask": {
@@ -926,118 +997,103 @@
       },
       "Description": "Mask of IMUs to enable fast sampling on, if available",
       "DisplayName": "Fast sampling mask",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Fast sampling mask\n    // @Description: Mask of IMUs to enable fast sampling on, if available\n    // @User: Advanced\n    // @Bitmask: 0:FirstIMU,1:SecondIMU,2:ThirdIMU"
+      "User": "Advanced"
     },
     "INS_GYR1_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the 1st gyroscope was calibrated at",
       "DisplayName": "Calibration temperature for 1st gyroscope",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 1st gyroscope\n    // @Description: Temperature that the 1st gyroscope was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR2OFFS_X": {
       "Calibration": "1",
       "Description": "Gyro2 sensor offsets of X axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro2 offsets of X axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro2 offsets of X axis\n    // @Description: Gyro2 sensor offsets of X axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR2OFFS_Y": {
       "Calibration": "1",
       "Description": "Gyro2 sensor offsets of Y axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro2 offsets of Y axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro2 offsets of Y axis\n    // @Description: Gyro2 sensor offsets of Y axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR2OFFS_Z": {
       "Calibration": "1",
       "Description": "Gyro2 sensor offsets of Z axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro2 offsets of Z axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro2 offsets of Z axis\n    // @Description: Gyro2 sensor offsets of Z axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR2_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the 2nd gyroscope was calibrated at",
       "DisplayName": "Calibration temperature for 2nd gyroscope",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 2nd gyroscope\n    // @Description: Temperature that the 2nd gyroscope was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR2_ID": {
       "Description": "Gyro2 sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Gyro2 ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro2 ID\n    // @Description: Gyro2 sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_GYR3OFFS_X": {
       "Calibration": "1",
       "Description": "Gyro3 sensor offsets of X axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro3 offsets of X axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro3 offsets of X axis\n    // @Description: Gyro3 sensor offsets of X axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR3OFFS_Y": {
       "Calibration": "1",
       "Description": "Gyro3 sensor offsets of Y axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro3 offsets of Y axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro3 offsets of Y axis\n    // @Description: Gyro3 sensor offsets of Y axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR3OFFS_Z": {
       "Calibration": "1",
       "Description": "Gyro3 sensor offsets of Z axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro3 offsets of Z axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro3 offsets of Z axis\n    // @Description: Gyro3 sensor offsets of Z axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR3_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the 3rd gyroscope was calibrated at",
       "DisplayName": "Calibration temperature for 3rd gyroscope",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for 3rd gyroscope\n    // @Description: Temperature that the 3rd gyroscope was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYR3_ID": {
       "Description": "Gyro3 sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Gyro3 ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro3 ID\n    // @Description: Gyro3 sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_GYROFFS_X": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of X axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of X axis\n    // @Description: Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYROFFS_Y": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Y axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Y axis\n    // @Description: Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYROFFS_Z": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Z axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Z axis\n    // @Description: Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_GYRO_FILTER": {
       "Description": "Filter cutoff frequency for gyroscopes. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)",
@@ -1047,8 +1103,7 @@
         "low": "0"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro filter cutoff frequency\n    // @Description: Filter cutoff frequency for gyroscopes. This can be set to a lower value to try to cope with very high vibration levels in aircraft. A value of zero means no filtering (not recommended!)\n    // @Units: Hz\n    // @Range: 0 256\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_GYRO_RATE": {
       "Description": "Gyro rate for IMUs with fast sampling enabled. The gyro rate is the sample rate at which the IMU filters operate and needs to be at least double the maximum filter frequency. If the sensor does not support the selected rate the next highest supported rate will be used. For IMUs which do not support fast sampling this setting is ignored and the default gyro rate of 1Khz is used.",
@@ -1060,8 +1115,7 @@
         "1": "2kHz",
         "2": "4kHz",
         "3": "8kHz"
-      },
-      "__field_text": "\n    // @DisplayName: Gyro rate for IMUs with Fast Sampling enabled\n    // @Description: Gyro rate for IMUs with fast sampling enabled. The gyro rate is the sample rate at which the IMU filters operate and needs to be at least double the maximum filter frequency. If the sensor does not support the selected rate the next highest supported rate will be used. For IMUs which do not support fast sampling this setting is ignored and the default gyro rate of 1Khz is used.\n    // @User: Advanced\n    // @Values: 0:1kHz,1:2kHz,2:4kHz,3:8kHz\n    // @RebootRequired: True"
+      }
     },
     "INS_GYR_CAL": {
       "Description": "Conrols when automatic gyro calibration is performed",
@@ -1070,15 +1124,13 @@
       "Values": {
         "0": "Never",
         "1": "Start-up only"
-      },
-      "__field_text": "\n    // @DisplayName: Gyro Calibration scheme\n    // @Description: Conrols when automatic gyro calibration is performed\n    // @Values: 0:Never, 1:Start-up only\n    // @User: Advanced"
+      }
     },
     "INS_GYR_ID": {
       "Description": "Gyro sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Gyro ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro ID\n    // @Description: Gyro sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS1_X": {
       "Description": "X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1089,8 +1141,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer X position\n    // @Description: X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS1_Y": {
       "Description": "Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1101,8 +1152,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Y position\n    // @Description: Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS1_Z": {
       "Description": "Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1113,8 +1163,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Z position\n    // @Description: Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS2_X": {
       "Description": "X position of the second IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1125,8 +1174,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer X position\n    // @Description: X position of the second IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS2_Y": {
       "Description": "Y position of the second IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1137,8 +1185,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Y position\n    // @Description: Y position of the second IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS2_Z": {
       "Description": "Z position of the second IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1149,8 +1196,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Z position\n    // @Description: Z position of the second IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS3_X": {
       "Description": "X position of the third IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1160,8 +1206,7 @@
         "low": "-10"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer X position\n    // @Description: X position of the third IMU accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -10 10\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS3_Y": {
       "Description": "Y position of the third IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1172,8 +1217,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Y position\n    // @Description: Y position of the third IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_POS3_Z": {
       "Description": "Z position of the third IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1184,8 +1228,18 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Z position\n    // @Description: Z position of the third IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
+    },
+    "INS_RAW_LOG_OPT": {
+      "Bitmask": {
+        "0": "Log primary gyro only",
+        "1": "Log all gyros",
+        "2": "Post filter",
+        "3": "Pre and post filter"
+      },
+      "Description": "Raw logging options bitmask",
+      "DisplayName": "Raw logging options",
+      "User": "Advanced"
     },
     "INS_STILL_THRESH": {
       "Description": "Threshold to tolerate vibration to determine if vehicle is motionless. This depends on the frame type and if there is a constant vibration due to motors before launch or after landing. Total motionless is about 0.05. Suggested values: Planes/rover use 0.1, multirotors use 1, tradHeli uses 5",
@@ -1194,17 +1248,16 @@
         "high": "50",
         "low": "0.05"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Stillness threshold for detecting if we are moving\n    // @Description: Threshold to tolerate vibration to determine if vehicle is motionless. This depends on the frame type and if there is a constant vibration due to motors before launch or after landing. Total motionless is about 0.05. Suggested values: Planes/rover use 0.1, multirotors use 1, tradHeli uses 5\n    // @Range: 0.05 50\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_TCAL_OPTIONS": {
       "Bitmask": {
-        "0": "PersistParams"
+        "0": "PersistTemps",
+        "1": "PersistAccels"
       },
-      "Description": "This enables optional temperature calibration features. Setting PersistParams will save the accelerometer and temperature calibration parameters in the bootloader sector on the next update of the bootloader.",
+      "Description": "This enables optional temperature calibration features. Setting of the Persist bits will save the temperature and/or accelerometer calibration parameters in the bootloader sector on the next update of the bootloader.",
       "DisplayName": "Options for temperature calibration",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Options for temperature calibration\n    // @Description: This enables optional temperature calibration features. Setting PersistParams will save the accelerometer and temperature calibration parameters in the bootloader sector on the next update of the bootloader.\n    // @Bitmask: 0:PersistParams\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_TRIM_OPTION": {
       "Description": "Specifies how the accel cal routine determines the trims",
@@ -1214,8 +1267,7 @@
         "0": "Don't adjust the trims",
         "1": "Assume first orientation was level",
         "2": "Assume ACC_BODYFIX is perfectly aligned to the vehicle"
-      },
-      "__field_text": "\n    // @DisplayName: Accel cal trim option\n    // @Description: Specifies how the accel cal routine determines the trims\n    // @User: Advanced\n    // @Values: 0:Don't adjust the trims,1:Assume first orientation was level,2:Assume ACC_BODYFIX is perfectly aligned to the vehicle"
+      }
     },
     "INS_USE": {
       "Description": "Use first IMU for attitude, velocity and position estimates",
@@ -1224,8 +1276,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Use first IMU for attitude, velocity and position estimates\n    // @Description: Use first IMU for attitude, velocity and position estimates\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     },
     "INS_USE2": {
       "Description": "Use second IMU for attitude, velocity and position estimates",
@@ -1234,8 +1285,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Use second IMU for attitude, velocity and position estimates\n    // @Description: Use second IMU for attitude, velocity and position estimates\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     },
     "INS_USE3": {
       "Description": "Use third IMU for attitude, velocity and position estimates",
@@ -1244,8 +1294,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Use third IMU for attitude, velocity and position estimates\n    // @Description: Use third IMU for attitude, velocity and position estimates\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     }
   },
   "INS4_": {
@@ -1258,8 +1307,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of X axis\n    // @Description: Accelerometer offsets of X axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACCOFFS_Y": {
       "Calibration": "1",
@@ -1270,8 +1318,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Y axis\n    // @Description: Accelerometer offsets of Y axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACCOFFS_Z": {
       "Calibration": "1",
@@ -1282,8 +1329,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Z axis\n    // @Description: Accelerometer offsets of Z axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACCSCAL_X": {
       "Calibration": "1",
@@ -1293,8 +1339,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of X axis\n    // @Description: Accelerometer scaling of X axis.  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACCSCAL_Y": {
       "Calibration": "1",
@@ -1304,8 +1349,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Y axis\n    // @Description: Accelerometer scaling of Y axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACCSCAL_Z": {
       "Calibration": "1",
@@ -1315,62 +1359,54 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Z axis\n    // @Description: Accelerometer scaling of Z axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACC_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the accelerometer was calibrated at",
       "DisplayName": "Calibration temperature for accelerometer",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for accelerometer\n    // @Description: Temperature that the accelerometer was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_ACC_ID": {
       "Description": "Accelerometer sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Accelerometer ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer ID\n    // @Description: Accelerometer sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS4_GYROFFS_X": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of X axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of X axis\n    // @Description: Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_GYROFFS_Y": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Y axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Y axis\n    // @Description: Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_GYROFFS_Z": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Z axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Z axis\n    // @Description: Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_GYR_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the gyroscope was calibrated at",
       "DisplayName": "Calibration temperature for gyroscope",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for gyroscope\n    // @Description: Temperature that the gyroscope was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_GYR_ID": {
       "Description": "Gyro sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Gyro ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro ID\n    // @Description: Gyro sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS4_POS_X": {
       "Description": "X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1381,8 +1417,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer X position\n    // @Description: X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS4_POS_Y": {
       "Description": "Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1393,8 +1428,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Y position\n    // @Description: Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS4_POS_Z": {
       "Description": "Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1405,8 +1439,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Z position\n    // @Description: Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS4_USE": {
       "Description": "Use first IMU for attitude, velocity and position estimates",
@@ -1415,8 +1448,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Use first IMU for attitude, velocity and position estimates\n    // @Description: Use first IMU for attitude, velocity and position estimates\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     }
   },
   "INS4_TCAL_": {
@@ -1424,64 +1456,55 @@
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ACC3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_ENABLE": {
       "Description": "Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot",
@@ -1492,71 +1515,61 @@
         "0": "Disabled",
         "1": "Enabled",
         "2": "LearnCalibration"
-      },
-      "__field_text": "\n    // @DisplayName: Enable temperature calibration\n    // @Description: Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot\n    // @Values: 0:Disabled,1:Enabled,2:LearnCalibration\n    // @User: Advanced\n    // @RebootRequired: True"
+      }
     },
     "INS4_TCAL_GYR1_X": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_GYR3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_TMAX": {
       "Calibration": "1",
@@ -1567,8 +1580,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration max\n    // @Description: The maximum temperature that the calibration is valid for. This must be at least 10 degrees above TMIN for calibration\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS4_TCAL_TMIN": {
       "Calibration": "1",
@@ -1579,8 +1591,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration min\n    // @Description: The minimum temperature that the calibration is valid for\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     }
   },
   "INS5_": {
@@ -1593,8 +1604,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of X axis\n    // @Description: Accelerometer offsets of X axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACCOFFS_Y": {
       "Calibration": "1",
@@ -1605,8 +1615,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Y axis\n    // @Description: Accelerometer offsets of Y axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACCOFFS_Z": {
       "Calibration": "1",
@@ -1617,8 +1626,7 @@
         "low": "-3.5"
       },
       "Units": "m/s/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer offsets of Z axis\n    // @Description: Accelerometer offsets of Z axis. This is setup using the acceleration calibration or level operations\n    // @Units: m/s/s\n    // @Range: -3.5 3.5\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACCSCAL_X": {
       "Calibration": "1",
@@ -1628,8 +1636,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of X axis\n    // @Description: Accelerometer scaling of X axis.  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACCSCAL_Y": {
       "Calibration": "1",
@@ -1639,8 +1646,7 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Y axis\n    // @Description: Accelerometer scaling of Y axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACCSCAL_Z": {
       "Calibration": "1",
@@ -1650,62 +1656,54 @@
         "high": "1.2",
         "low": "0.8"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer scaling of Z axis\n    // @Description: Accelerometer scaling of Z axis  Calculated during acceleration calibration routine\n    // @Range: 0.8 1.2\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACC_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the accelerometer was calibrated at",
       "DisplayName": "Calibration temperature for accelerometer",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for accelerometer\n    // @Description: Temperature that the accelerometer was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_ACC_ID": {
       "Description": "Accelerometer sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Accelerometer ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer ID\n    // @Description: Accelerometer sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS5_GYROFFS_X": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of X axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of X axis\n    // @Description: Gyro sensor offsets of X axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_GYROFFS_Y": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Y axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Y axis\n    // @Description: Gyro sensor offsets of Y axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_GYROFFS_Z": {
       "Calibration": "1",
       "Description": "Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations",
       "DisplayName": "Gyro offsets of Z axis",
       "Units": "rad/s",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro offsets of Z axis\n    // @Description: Gyro sensor offsets of Z axis. This is setup on each boot during gyro calibrations\n    // @Units: rad/s\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_GYR_CALTEMP": {
       "Calibration": "1",
       "Description": "Temperature that the gyroscope was calibrated at",
       "DisplayName": "Calibration temperature for gyroscope",
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Calibration temperature for gyroscope\n    // @Description: Temperature that the gyroscope was calibrated at\n    // @User: Advanced\n    // @Units: degC\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_GYR_ID": {
       "Description": "Gyro sensor ID, taking into account its type, bus and instance",
       "DisplayName": "Gyro ID",
       "ReadOnly": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyro ID\n    // @Description: Gyro sensor ID, taking into account its type, bus and instance\n    // @ReadOnly: True\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS5_POS_X": {
       "Description": "X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1716,8 +1714,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer X position\n    // @Description: X position of the first IMU Accelerometer in body frame. Positive X is forward of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS5_POS_Y": {
       "Description": "Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1728,8 +1725,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Y position\n    // @Description: Y position of the first IMU accelerometer in body frame. Positive Y is to the right of the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS5_POS_Z": {
       "Description": "Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.",
@@ -1740,8 +1736,7 @@
         "low": "-5"
       },
       "Units": "m",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: IMU accelerometer Z position\n    // @Description: Z position of the first IMU accelerometer in body frame. Positive Z is down from the origin. Attention: The IMU should be located as close to the vehicle c.g. as practical so that the value of this parameter is minimised. Failure to do so can result in noisy navigation velocity measurements due to vibration and IMU gyro noise. If the IMU cannot be moved and velocity noise is a problem, a location closer to the IMU can be used as the body frame origin.\n    // @Units: m\n    // @Range: -5 5\n    // @Increment: 0.01\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS5_USE": {
       "Description": "Use first IMU for attitude, velocity and position estimates",
@@ -1750,8 +1745,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Use first IMU for attitude, velocity and position estimates\n    // @Description: Use first IMU for attitude, velocity and position estimates\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     }
   },
   "INS5_TCAL_": {
@@ -1759,64 +1753,55 @@
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ACC3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_ENABLE": {
       "Description": "Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot",
@@ -1827,71 +1812,61 @@
         "0": "Disabled",
         "1": "Enabled",
         "2": "LearnCalibration"
-      },
-      "__field_text": "\n    // @DisplayName: Enable temperature calibration\n    // @Description: Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot\n    // @Values: 0:Disabled,1:Enabled,2:LearnCalibration\n    // @User: Advanced\n    // @RebootRequired: True"
+      }
     },
     "INS5_TCAL_GYR1_X": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_GYR3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_TMAX": {
       "Calibration": "1",
@@ -1902,8 +1877,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration max\n    // @Description: The maximum temperature that the calibration is valid for. This must be at least 10 degrees above TMIN for calibration\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS5_TCAL_TMIN": {
       "Calibration": "1",
@@ -1914,8 +1888,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration min\n    // @Description: The minimum temperature that the calibration is valid for\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     }
   },
   "INS_HNTC2_": {
@@ -1927,8 +1900,7 @@
         "low": "5"
       },
       "Units": "dB",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter attenuation\n    // @Description: Harmonic Notch Filter attenuation in dB. Values greater than 40dB will typically produce a hard notch rather than a modest attenuation of motor noise.\n    // @Range: 5 50\n    // @Units: dB\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTC2_BW": {
       "Description": "Harmonic Notch Filter bandwidth in Hz. This is typically set to half the base frequency. The ratio of base frequency to bandwidth determines the notch quality factor and is fixed across harmonics.",
@@ -1938,8 +1910,7 @@
         "low": "5"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter bandwidth\n    // @Description: Harmonic Notch Filter bandwidth in Hz. This is typically set to half the base frequency. The ratio of base frequency to bandwidth determines the notch quality factor and is fixed across harmonics.\n    // @Range: 5 250\n    // @Units: Hz\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTC2_ENABLE": {
       "Description": "Harmonic Notch Filter enable",
@@ -1948,8 +1919,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter enable\n    // @Description: Harmonic Notch Filter enable\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     },
     "INS_HNTC2_FM_RAT": {
       "Description": "The minimum ratio below the configured frequency to take throttle based notch filters when flying at a throttle level below the reference throttle. Note that lower frequency notch filters will have more phase lag. If you want throttle based notch filtering to be effective at a throttle up to 30% below the configured notch frequency then set this parameter to 0.7. The default of 1.0 means the notch will not go below the frequency in the FREQ parameter.",
@@ -1958,8 +1928,7 @@
         "high": "1.0",
         "low": "0.1"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle notch min freqency ratio\n    // @Description: The minimum ratio below the configured frequency to take throttle based notch filters when flying at a throttle level below the reference throttle. Note that lower frequency notch filters will have more phase lag. If you want throttle based notch filtering to be effective at a throttle up to 30% below the configured notch frequency then set this parameter to 0.7. The default of 1.0 means the notch will not go below the frequency in the FREQ parameter.\n    // @Range: 0.1 1.0\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTC2_FREQ": {
       "Description": "Harmonic Notch Filter base center frequency in Hz. This is the center frequency for static notches, the center frequency for Throttle based notches at the reference thrust value, and the minimum limit of center frequency variation for all other notch types. This should always be set lower than half the backend gyro rate (which is typically 1Khz). ",
@@ -1969,8 +1938,7 @@
         "low": "10"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter base frequency\n    // @Description: Harmonic Notch Filter base center frequency in Hz. This is the center frequency for static notches, the center frequency for Throttle based notches at the reference thrust value, and the minimum limit of center frequency variation for all other notch types. This should always be set lower than half the backend gyro rate (which is typically 1Khz). \n    // @Range: 10 495\n    // @Units: Hz\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTC2_HMNCS": {
       "Bitmask": {
@@ -1994,11 +1962,10 @@
       "Description": "Bitmask of harmonic frequencies to apply Harmonic Notch Filter to. This option takes effect on the next reboot. A value of 0 disables this filter. The first harmonic refers to the base frequency.",
       "DisplayName": "Harmonic Notch Filter harmonics",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter harmonics\n    // @Description: Bitmask of harmonic frequencies to apply Harmonic Notch Filter to. This option takes effect on the next reboot. A value of 0 disables this filter. The first harmonic refers to the base frequency.\n    // @Bitmask: 0:1st harmonic,1:2nd harmonic,2:3rd harmonic,3:4th hamronic,4:5th harmonic,5:6th harmonic,6:7th harmonic,7:8th harmonic\n    // @User: Advanced\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_HNTC2_MODE": {
-      "Description": "Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based updates should only be used with multicopters.",
+      "Description": "Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based harmonic notch cannot be used on fixed wing only planes. It can for Copters, QuaadPlane(while in VTOL modes), and Rovers.",
       "DisplayName": "Harmonic Notch Filter dynamic frequency tracking mode",
       "Range": {
         "high": "5",
@@ -2012,8 +1979,7 @@
         "3": "ESC Telemetry",
         "4": "Dynamic FFT",
         "5": "Second RPM Sensor"
-      },
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter dynamic frequency tracking mode\n    // @Description: Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based updates should only be used with multicopters.\n    // @Range: 0 5\n    // @Values: 0:Fixed,1:Throttle,2:RPM Sensor,3:ESC Telemetry,4:Dynamic FFT,5:Second RPM Sensor\n    // @User: Advanced"
+      }
     },
     "INS_HNTC2_OPTS": {
       "Bitmask": {
@@ -2021,13 +1987,13 @@
         "1": "Multi-Source",
         "2": "Update at loop rate",
         "3": "EnableOnAllIMUs",
-        "4": "Triple notch"
+        "4": "Triple notch",
+        "5": "Use min freq on RPM source failure"
       },
       "Description": "Harmonic Notch Filter options. Triple and double-notches can provide deeper attenuation across a wider bandwidth with reduced latency than single notches and are suitable for larger aircraft. Multi-Source attaches a harmonic notch to each detected noise frequency instead of simply being multiples of the base frequency, in the case of FFT it will attach notches to each of three detected noise peaks, in the case of ESC it will attach notches to each of four motor RPM values. Loop rate update changes the notch center frequency at the scheduler loop rate rather than at the default of 200Hz. If both double and triple notches are specified only double notches will take effect.",
       "DisplayName": "Harmonic Notch Filter options",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter options\n    // @Description: Harmonic Notch Filter options. Triple and double-notches can provide deeper attenuation across a wider bandwidth with reduced latency than single notches and are suitable for larger aircraft. Multi-Source attaches a harmonic notch to each detected noise frequency instead of simply being multiples of the base frequency, in the case of FFT it will attach notches to each of three detected noise peaks, in the case of ESC it will attach notches to each of four motor RPM values. Loop rate update changes the notch center frequency at the scheduler loop rate rather than at the default of 200Hz. If both double and triple notches are specified only double notches will take effect.\n    // @Bitmask: 0:Double notch,1:Multi-Source,2:Update at loop rate,3:EnableOnAllIMUs,4:Triple notch\n    // @User: Advanced\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_HNTC2_REF": {
       "Description": "A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For throttle-based scaling, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For RPM and ESC telemetry based tracking, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor or ESC telemetry set to measure rotor speed.  The sensor data is converted to Hz automatically for use in the Harmonic Notch Filter.  This reference value may also be used to scale the sensor data, if required.  For example, rpm sensor data is required to measure heli motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.",
@@ -2037,8 +2003,7 @@
         "low": "0.0"
       },
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter reference value\n    // @Description: A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For throttle-based scaling, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For RPM and ESC telemetry based tracking, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor or ESC telemetry set to measure rotor speed.  The sensor data is converted to Hz automatically for use in the Harmonic Notch Filter.  This reference value may also be used to scale the sensor data, if required.  For example, rpm sensor data is required to measure heli motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.\n    // @User: Advanced\n    // @Range: 0.0 1.0\n    // @RebootRequired: True"
+      "User": "Advanced"
     }
   },
   "INS_HNTCH_": {
@@ -2050,8 +2015,7 @@
         "low": "5"
       },
       "Units": "dB",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter attenuation\n    // @Description: Harmonic Notch Filter attenuation in dB. Values greater than 40dB will typically produce a hard notch rather than a modest attenuation of motor noise.\n    // @Range: 5 50\n    // @Units: dB\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTCH_BW": {
       "Description": "Harmonic Notch Filter bandwidth in Hz. This is typically set to half the base frequency. The ratio of base frequency to bandwidth determines the notch quality factor and is fixed across harmonics.",
@@ -2061,8 +2025,7 @@
         "low": "5"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter bandwidth\n    // @Description: Harmonic Notch Filter bandwidth in Hz. This is typically set to half the base frequency. The ratio of base frequency to bandwidth determines the notch quality factor and is fixed across harmonics.\n    // @Range: 5 250\n    // @Units: Hz\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTCH_ENABLE": {
       "Description": "Harmonic Notch Filter enable",
@@ -2071,8 +2034,7 @@
       "Values": {
         "0": "Disabled",
         "1": "Enabled"
-      },
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter enable\n    // @Description: Harmonic Notch Filter enable\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+      }
     },
     "INS_HNTCH_FM_RAT": {
       "Description": "The minimum ratio below the configured frequency to take throttle based notch filters when flying at a throttle level below the reference throttle. Note that lower frequency notch filters will have more phase lag. If you want throttle based notch filtering to be effective at a throttle up to 30% below the configured notch frequency then set this parameter to 0.7. The default of 1.0 means the notch will not go below the frequency in the FREQ parameter.",
@@ -2081,8 +2043,7 @@
         "high": "1.0",
         "low": "0.1"
       },
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Throttle notch min freqency ratio\n    // @Description: The minimum ratio below the configured frequency to take throttle based notch filters when flying at a throttle level below the reference throttle. Note that lower frequency notch filters will have more phase lag. If you want throttle based notch filtering to be effective at a throttle up to 30% below the configured notch frequency then set this parameter to 0.7. The default of 1.0 means the notch will not go below the frequency in the FREQ parameter.\n    // @Range: 0.1 1.0\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTCH_FREQ": {
       "Description": "Harmonic Notch Filter base center frequency in Hz. This is the center frequency for static notches, the center frequency for Throttle based notches at the reference thrust value, and the minimum limit of center frequency variation for all other notch types. This should always be set lower than half the backend gyro rate (which is typically 1Khz). ",
@@ -2092,8 +2053,7 @@
         "low": "10"
       },
       "Units": "Hz",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter base frequency\n    // @Description: Harmonic Notch Filter base center frequency in Hz. This is the center frequency for static notches, the center frequency for Throttle based notches at the reference thrust value, and the minimum limit of center frequency variation for all other notch types. This should always be set lower than half the backend gyro rate (which is typically 1Khz). \n    // @Range: 10 495\n    // @Units: Hz\n    // @User: Advanced"
+      "User": "Advanced"
     },
     "INS_HNTCH_HMNCS": {
       "Bitmask": {
@@ -2117,11 +2077,10 @@
       "Description": "Bitmask of harmonic frequencies to apply Harmonic Notch Filter to. This option takes effect on the next reboot. A value of 0 disables this filter. The first harmonic refers to the base frequency.",
       "DisplayName": "Harmonic Notch Filter harmonics",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter harmonics\n    // @Description: Bitmask of harmonic frequencies to apply Harmonic Notch Filter to. This option takes effect on the next reboot. A value of 0 disables this filter. The first harmonic refers to the base frequency.\n    // @Bitmask: 0:1st harmonic,1:2nd harmonic,2:3rd harmonic,3:4th hamronic,4:5th harmonic,5:6th harmonic,6:7th harmonic,7:8th harmonic\n    // @User: Advanced\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_HNTCH_MODE": {
-      "Description": "Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based updates should only be used with multicopters.",
+      "Description": "Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based harmonic notch cannot be used on fixed wing only planes. It can for Copters, QuaadPlane(while in VTOL modes), and Rovers.",
       "DisplayName": "Harmonic Notch Filter dynamic frequency tracking mode",
       "Range": {
         "high": "5",
@@ -2135,8 +2094,7 @@
         "3": "ESC Telemetry",
         "4": "Dynamic FFT",
         "5": "Second RPM Sensor"
-      },
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter dynamic frequency tracking mode\n    // @Description: Harmonic Notch Filter dynamic frequency tracking mode. Dynamic updates can be throttle, RPM sensor, ESC telemetry or dynamic FFT based. Throttle-based updates should only be used with multicopters.\n    // @Range: 0 5\n    // @Values: 0:Fixed,1:Throttle,2:RPM Sensor,3:ESC Telemetry,4:Dynamic FFT,5:Second RPM Sensor\n    // @User: Advanced"
+      }
     },
     "INS_HNTCH_OPTS": {
       "Bitmask": {
@@ -2144,13 +2102,13 @@
         "1": "Multi-Source",
         "2": "Update at loop rate",
         "3": "EnableOnAllIMUs",
-        "4": "Triple notch"
+        "4": "Triple notch",
+        "5": "Use min freq on RPM source failure"
       },
       "Description": "Harmonic Notch Filter options. Triple and double-notches can provide deeper attenuation across a wider bandwidth with reduced latency than single notches and are suitable for larger aircraft. Multi-Source attaches a harmonic notch to each detected noise frequency instead of simply being multiples of the base frequency, in the case of FFT it will attach notches to each of three detected noise peaks, in the case of ESC it will attach notches to each of four motor RPM values. Loop rate update changes the notch center frequency at the scheduler loop rate rather than at the default of 200Hz. If both double and triple notches are specified only double notches will take effect.",
       "DisplayName": "Harmonic Notch Filter options",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter options\n    // @Description: Harmonic Notch Filter options. Triple and double-notches can provide deeper attenuation across a wider bandwidth with reduced latency than single notches and are suitable for larger aircraft. Multi-Source attaches a harmonic notch to each detected noise frequency instead of simply being multiples of the base frequency, in the case of FFT it will attach notches to each of three detected noise peaks, in the case of ESC it will attach notches to each of four motor RPM values. Loop rate update changes the notch center frequency at the scheduler loop rate rather than at the default of 200Hz. If both double and triple notches are specified only double notches will take effect.\n    // @Bitmask: 0:Double notch,1:Multi-Source,2:Update at loop rate,3:EnableOnAllIMUs,4:Triple notch\n    // @User: Advanced\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_HNTCH_REF": {
       "Description": "A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For throttle-based scaling, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For RPM and ESC telemetry based tracking, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor or ESC telemetry set to measure rotor speed.  The sensor data is converted to Hz automatically for use in the Harmonic Notch Filter.  This reference value may also be used to scale the sensor data, if required.  For example, rpm sensor data is required to measure heli motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.",
@@ -2160,8 +2118,7 @@
         "low": "0.0"
       },
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Harmonic Notch Filter reference value\n    // @Description: A reference value of zero disables dynamic updates on the Harmonic Notch Filter and a positive value enables dynamic updates on the Harmonic Notch Filter.  For throttle-based scaling, this parameter is the reference value associated with the specified frequency to facilitate frequency scaling of the Harmonic Notch Filter. For RPM and ESC telemetry based tracking, this parameter is set to 1 to enable the Harmonic Notch Filter using the RPM sensor or ESC telemetry set to measure rotor speed.  The sensor data is converted to Hz automatically for use in the Harmonic Notch Filter.  This reference value may also be used to scale the sensor data, if required.  For example, rpm sensor data is required to measure heli motor RPM. Therefore the reference value can be used to scale the RPM sensor to the rotor RPM.\n    // @User: Advanced\n    // @Range: 0.0 1.0\n    // @RebootRequired: True"
+      "User": "Advanced"
     }
   },
   "INS_LOG_": {
@@ -2170,21 +2127,18 @@
       "DisplayName": "sample count per batch",
       "Increment": "32",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: sample count per batch\n    // @Description: Number of samples to take when logging streams of IMU sensor readings.  Will be rounded down to a multiple of 32. This option takes effect on the next reboot.\n    // @User: Advanced\n    // @Increment: 32\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_LOG_BAT_LGCT": {
       "Description": "Number of samples to push to count every INS_LOG_BAT_LGIN",
       "DisplayName": "logging count",
-      "Increment": "1",
-      "__field_text": "\n    // @DisplayName: logging count\n    // @Description: Number of samples to push to count every @PREFIX@BAT_LGIN\n    // @Increment: 1"
+      "Increment": "1"
     },
     "INS_LOG_BAT_LGIN": {
       "Description": "Interval between pushing samples to the AP_Logger log",
       "DisplayName": "logging interval",
       "Increment": "10",
-      "Units": "ms",
-      "__field_text": "\n    // @DisplayName: logging interval\n    // @Description: Interval between pushing samples to the AP_Logger log\n    // @Units: ms\n    // @Increment: 10"
+      "Units": "ms"
     },
     "INS_LOG_BAT_MASK": {
       "Bitmask": {
@@ -2195,8 +2149,7 @@
       "Description": "Bitmap of which IMUs to log batch data for. This option takes effect on the next reboot.",
       "DisplayName": "Sensor Bitmask",
       "RebootRequired": "True",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Sensor Bitmask\n    // @Description: Bitmap of which IMUs to log batch data for. This option takes effect on the next reboot.\n    // @User: Advanced\n    // @Bitmask: 0:IMU1,1:IMU2,2:IMU3\n    // @RebootRequired: True"
+      "User": "Advanced"
     },
     "INS_LOG_BAT_OPT": {
       "Bitmask": {
@@ -2206,8 +2159,7 @@
       },
       "Description": "Options for the BatchSampler.",
       "DisplayName": "Batch Logging Options Mask",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Batch Logging Options Mask\n    // @Description: Options for the BatchSampler.\n    // @Bitmask: 0:Sensor-Rate Logging (sample at full sensor rate seen by AP), 1: Sample post-filtering, 2: Sample pre- and post-filter\n    // @User: Advanced"
+      "User": "Advanced"
     }
   },
   "INS_TCAL1_": {
@@ -2215,64 +2167,55 @@
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ACC3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_ENABLE": {
       "Description": "Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot",
@@ -2283,71 +2226,61 @@
         "0": "Disabled",
         "1": "Enabled",
         "2": "LearnCalibration"
-      },
-      "__field_text": "\n    // @DisplayName: Enable temperature calibration\n    // @Description: Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot\n    // @Values: 0:Disabled,1:Enabled,2:LearnCalibration\n    // @User: Advanced\n    // @RebootRequired: True"
+      }
     },
     "INS_TCAL1_GYR1_X": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_GYR3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_TMAX": {
       "Calibration": "1",
@@ -2358,8 +2291,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration max\n    // @Description: The maximum temperature that the calibration is valid for. This must be at least 10 degrees above TMIN for calibration\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL1_TMIN": {
       "Calibration": "1",
@@ -2370,8 +2302,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration min\n    // @Description: The minimum temperature that the calibration is valid for\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     }
   },
   "INS_TCAL2_": {
@@ -2379,64 +2310,55 @@
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ACC3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_ENABLE": {
       "Description": "Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot",
@@ -2447,71 +2369,61 @@
         "0": "Disabled",
         "1": "Enabled",
         "2": "LearnCalibration"
-      },
-      "__field_text": "\n    // @DisplayName: Enable temperature calibration\n    // @Description: Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot\n    // @Values: 0:Disabled,1:Enabled,2:LearnCalibration\n    // @User: Advanced\n    // @RebootRequired: True"
+      }
     },
     "INS_TCAL2_GYR1_X": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_GYR3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_TMAX": {
       "Calibration": "1",
@@ -2522,8 +2434,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration max\n    // @Description: The maximum temperature that the calibration is valid for. This must be at least 10 degrees above TMIN for calibration\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL2_TMIN": {
       "Calibration": "1",
@@ -2534,8 +2445,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration min\n    // @Description: The minimum temperature that the calibration is valid for\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     }
   },
   "INS_TCAL3_": {
@@ -2543,64 +2453,55 @@
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ACC3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Accelerometer 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Accelerometer 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_ENABLE": {
       "Description": "Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot",
@@ -2611,71 +2512,61 @@
         "0": "Disabled",
         "1": "Enabled",
         "2": "LearnCalibration"
-      },
-      "__field_text": "\n    // @DisplayName: Enable temperature calibration\n    // @Description: Enable the use of temperature calibration parameters for this IMU. For automatic learning set to 2 and also set the INS_TCALn_TMAX to the target temperature, then reboot\n    // @Values: 0:Disabled,1:Enabled,2:LearnCalibration\n    // @User: Advanced\n    // @RebootRequired: True"
+      }
     },
     "INS_TCAL3_GYR1_X": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient X axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR1_Y": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Y axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR1_Z": {
       "Calibration": "1",
       "Description": "This is the 1st order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 1st order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 1st order temperature coefficient Z axis\n    // @Description: This is the 1st order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR2_X": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient X axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR2_Y": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Y axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR2_Z": {
       "Calibration": "1",
       "Description": "This is the 2nd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 2nd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 2nd order temperature coefficient Z axis\n    // @Description: This is the 2nd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR3_X": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient X axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient X axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR3_Y": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Y axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Y axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_GYR3_Z": {
       "Calibration": "1",
       "Description": "This is the 3rd order temperature coefficient from a temperature calibration",
       "DisplayName": "Gyroscope 3rd order temperature coefficient Z axis",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Gyroscope 3rd order temperature coefficient Z axis\n    // @Description: This is the 3rd order temperature coefficient from a temperature calibration\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_TMAX": {
       "Calibration": "1",
@@ -2686,8 +2577,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration max\n    // @Description: The maximum temperature that the calibration is valid for. This must be at least 10 degrees above TMIN for calibration\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     },
     "INS_TCAL3_TMIN": {
       "Calibration": "1",
@@ -2698,8 +2588,7 @@
         "low": "-70"
       },
       "Units": "degC",
-      "User": "Advanced",
-      "__field_text": "\n    // @DisplayName: Temperature calibration min\n    // @Description: The minimum temperature that the calibration is valid for\n    // @Range: -70 80\n    // @Units: degC\n    // @User: Advanced\n    // @Calibration: 1"
+      "User": "Advanced"
     }
   },
   "SCHED_": {


### PR DESCRIPTION
This adds support for 4.6 filtering as updated by https://github.com/ArduPilot/ardupilot/pull/25442. 

The key change is that notches are faded out with a low source frequency rather than being held at the min frequency.