### PR TITLE
TelemetryDashboard: Auto connect to MissionPlanner

### DIFF
--- a/Dev/index.html
+++ b/Dev/index.html
@@ -79,7 +79,7 @@ The tools on this page are either developer focused, or a work in progress, they
     </td>
     <td style="text-align:left; vertical-align:top; max-width:960px;">
       <h2>TelemetryDashboard</h2>
-      Telemetry Dashboard allows customizable data displays from a MAVLink telemetry stream. Requires a WebSocket server to forward raw binary MAVLink, latest PyMAVLink can be used eg: <a href="https://github.com/IamPete1/pymavlink/blob/WebSocket_forwarding_example/examples/mavtcpsniff.py">TCP to WebSocket</a>. 
+      Telemetry Dashboard allows customizable data displays from a MAVLink telemetry stream. Requires a WebSocket server to forward raw binary MAVLink. Attempts to auto connect to MissionPlanner at <code>ws://127.0.0.1:56781</code>. Latest PyMAVLink can also be used eg: <a href="https://github.com/IamPete1/pymavlink/blob/WebSocket_forwarding_example/examples/mavtcpsniff.py">TCP to WebSocket</a>. 
       This is read only, MAVLink commands are not sent (including stream rate requests). 
       This is not a GCS replacement.
     </td>

--- a/TelemetryDashboard/TelemetryDashboard.js
+++ b/TelemetryDashboard/TelemetryDashboard.js
@@ -49,6 +49,7 @@ function setup_connect(button_svg, button_color) {
     // Websocket object
     let ws = null
     let expecting_close = false
+    let been_connected = false
 
     function set_inputs(connected) {
         // Disable connect button and url input, enable disconnect button
@@ -60,7 +61,7 @@ function setup_connect(button_svg, button_color) {
     set_inputs(false)
 
     // Connect to WebSocket server
-    function connect(target) {
+    function connect(target, auto_connect) {
         // Make sure we are not connected to something else
         disconnect()
 
@@ -69,6 +70,9 @@ function setup_connect(button_svg, button_color) {
 
         // Set orange for connecting
         button_color("orange")
+
+        // True if we have ever been connected
+        been_connected = false
 
         ws = new WebSocket(target)
         ws.binaryType = "arraybuffer"
@@ -83,10 +87,21 @@ function setup_connect(button_svg, button_color) {
 
             // Allow disconnect
             disconnect_button.disabled = false
+
+            // Set input to current value
+            url_input.value = target
+
+            // Have been connected
+            been_connected = true
         }
 
         ws.onclose = () => {
-            if (!expecting_close) {
+            if ((auto_connect === true) && !been_connected) {
+                // Don't show a failed connection if this is a auto connection attempt which failed
+                button_color("black")
+
+            } else if (!expecting_close) {
+                // Don't show red if the user manually disconnected
                 button_color("red")
             }
 
@@ -162,6 +177,9 @@ function setup_connect(button_svg, button_color) {
 
         disconnect()
     }
+
+    // Try auto connecting to MissionPlanner
+    connect("ws://127.0.0.1:56781", true)
 
 }
 

--- a/TelemetryDashboard/index.html
+++ b/TelemetryDashboard/index.html
@@ -170,7 +170,7 @@
                 <label for="target_url">Server address</label>&nbsp
                 <img id="TT" src="../images/question-circle.svg" style="width: 1em;"
                 data-tippy-allowHTML="true"
-                data-tippy-content='Connection address for WebSocket server forwarding raw binary MAVLink, latest PyMAVLink can be used eg: <a href="https://github.com/IamPete1/pymavlink/blob/WebSocket_forwarding_example/examples/mavtcpsniff.py">TCP to WebSocket</a>. 
+                data-tippy-content='Connection address for WebSocket server forwarding raw binary MAVLink. Attempts to auto connect to MissionPlanner at <code>ws://127.0.0.1:56781</code>. Latest PyMAVLink can also be used eg: <a href="https://github.com/IamPete1/pymavlink/blob/WebSocket_forwarding_example/examples/mavtcpsniff.py">TCP to WebSocket</a>. 
                 This is read only, MAVLink commands are not sent (including stream rate requests).'/>
                 <br>
                 <input id="target_url" type="url" placeholder="ws://127.0.0.1:5863" required="true" pattern="^(ws|wss)://.*">


### PR DESCRIPTION
Turns out MissionPlanner already forwards a stream, this adds autoconnection to `ws://127.0.0.1:56781`. 