### PR TITLE
FilterReview: tracking: logged notch: remove array spread to remove large call stack

### DIFF
--- a/FilterReview/tracking/Logged.js
+++ b/FilterReview/tracking/Logged.js
@@ -30,7 +30,12 @@ class LoggedNotch extends NotchTarget {
                     continue
                 }
 
-                const num_notches = Math.max(...log.get_instance(dynamic_msg, inst, "NDn"))
+                const notch_number = log.get_instance(dynamic_msg, inst, "NDn")
+                let num_notches = 0
+                const len = notch_number.length
+                for (let i = 0; i<len; i++) {
+                    num_notches = Math.max(num_notches, notch_number[i])
+                }
 
                 this.data.time = TimeUS_to_seconds(log.get_instance(dynamic_msg, inst, "TimeUS"))
 


### PR DESCRIPTION
This spread was resulting in passing too many arguments to the max method. Swapping iterating over the list removes the issue. https://github.com/ArduPilot/WebTools/issues/195