### PR TITLE
Libraries: Ensure SHA padding

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1714,7 +1714,7 @@ function load_can(log) {
                 version: CAND.Major[i] + "." + CAND.Minor[i],
                 UID1: CAND.UID1[i],
                 UID2: CAND.UID2[i],
-                hash: CAND.Version[i].toString(16)
+                hash: CAND.Version[i].toString(16).padStart(8, '0')
             }
 
             // Check for duplicates

--- a/Libraries/LogHelpers.js
+++ b/Libraries/LogHelpers.js
@@ -16,7 +16,7 @@ function get_version_and_board(log) {
 
         // Assume version does not change, just use first msg
         fw_string = VER.FWS[0]
-        fw_hash = VER.GH[0].toString(16)
+        fw_hash = VER.GH[0].toString(16).padStart(8, '0')
         if (VER.APJ[0] != 0) {
             board_id = VER.APJ[0]
         }


### PR DESCRIPTION
Commits with leading zeroes in SHA would lose them in the number to string conversion, leading to a false-negative GitHub check

![image](https://github.com/user-attachments/assets/3e912f4c-882b-44f1-8594-7baed4d1e222)
