### PR TITLE
ThrustExpo: small updates to layout, fix couple of items missing in reset and add error catcher

### DIFF
--- a/ThrustExpo/ThrustExpo.css
+++ b/ThrustExpo/ThrustExpo.css
@@ -109,7 +109,7 @@ img.tooltip-trigger {
 
 #app-description {
     width: 100%;
-    max-width: 800px;
+    max-width: 1200px;
     text-align: justify;
     padding: 20px 0px;
 }
@@ -118,10 +118,6 @@ img.tooltip-trigger {
     font-family: sans-serif;
     font-size: 0.8rem;
     width: 100%;
-    max-width: 570px;
+    max-width: 1200px;
     margin-left: 3px;
-}
-
-#hover-thrust-estimate {
-    display: none;
 }

--- a/ThrustExpo/ThrustExpo.css
+++ b/ThrustExpo/ThrustExpo.css
@@ -9,7 +9,8 @@ h1 a {
 
 fieldset {
     width: 100%;
-    width: 550px;
+    max-width: 550px;
+    height: 130px;
     font-family: sans-serif;
     font-size: 0.8rem;
     padding-top: 10px;
@@ -71,7 +72,6 @@ img.tooltip-trigger {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 3rem;
-    padding-top: 10px;
 }
 
 .param-column {

--- a/ThrustExpo/ThrustExpo.js
+++ b/ThrustExpo/ThrustExpo.js
@@ -754,7 +754,16 @@ function initThrustTable() {
     let updateTimeout = null;
 
     const onDataChanged = function () {
-        //update table height as necessary
+        // update chart after changes stop
+        // (paste actions call this repeatedly, so debounce a little)
+        clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(() => {
+            updatePlotData();
+        }, 100);
+    };
+
+    const onRenderComplete = function() {
+        // update table height as necessary
         const rowCount = thrustTable.getRows().length;
         const headerHeight =
             thrustTable.element.querySelector(".tabulator-header").offsetHeight;
@@ -766,17 +775,10 @@ function initThrustTable() {
             currentHeight = newHeight;
             thrustTable.setHeight(`${newHeight}px`);
         }
-
-        // update chart after changes stop
-        // (paste actions call this repeatedly, so debounce a little)
-        clearTimeout(updateTimeout);
-        updateTimeout = setTimeout(() => {
-            updatePlotData();
-        }, 100);
-    };
+    }
 
     thrustTable.on("dataChanged", onDataChanged);
-    thrustTable.on("renderComplete", onDataChanged);
+    thrustTable.on("renderComplete", onRenderComplete);
 
     // if the last row is edited, add a new row
     thrustTable.on("cellEdited", function (cell) {

--- a/ThrustExpo/ThrustExpo.js
+++ b/ThrustExpo/ThrustExpo.js
@@ -195,6 +195,7 @@ function updateThrustExpoPlot(thrustExpo = null) {
             thrustExpoPlot.layout
         );
         thrustErrorPlot.data = [];
+        thrustErrorPlot.layout.shapes[0].visible = false
         Plotly.react(
             thrustErrorPlot.plot,
             thrustErrorPlot.data,
@@ -212,10 +213,10 @@ function updateThrustExpoPlot(thrustExpo = null) {
         current: new Array(data_length),
     };
     for (let i = 0; i < data_length; i++) {
-        data.pwm[i] = thrustData[i].pwm;
-        data.thrust[i] = thrustData[i].thrust;
-        data.voltage[i] = thrustData[i].voltage;
-        data.current[i] = thrustData[i].current;
+        data.pwm[i] = parseFloat(thrustData[i].pwm);
+        data.thrust[i] = parseFloat(thrustData[i].thrust);
+        data.voltage[i] = parseFloat(thrustData[i].voltage);
+        data.current[i] = parseFloat(thrustData[i].current);
     }
 
     // Test at actuator values from 0 to 1
@@ -453,6 +454,7 @@ function updateThrustExpoPlot(thrustExpo = null) {
     ];
     thrustErrorPlot.layout.shapes[0].y0 = result.mean;
     thrustErrorPlot.layout.shapes[0].y1 = result.mean;
+    thrustErrorPlot.layout.shapes[0].visible = true
     Plotly.react(
         thrustErrorPlot.plot,
         thrustErrorPlot.data,
@@ -574,6 +576,7 @@ function initThrustErrorPlot() {
                     width: 1,
                     color: "gray",
                 },
+                visible: false
             },
         ],
     };
@@ -815,6 +818,7 @@ function reset() {
             current: "",
         }))
     );
+    updatePlotData();
 }
 
 function loadExample() {
@@ -897,6 +901,7 @@ function loadExample() {
         { pwm: 1989, thrust: 2.233, voltage: 21.52, current: 13.511 },
         { pwm: 2000, thrust: 2.254, voltage: 21.52, current: 13.854 },
     ]);
+    updatePlotData();
     const copterAuwElement = document.getElementById("COPTER_AUW");
     copterAuwElement.value = 2.5;
     copterAuwElement.dispatchEvent(new Event("change"));

--- a/ThrustExpo/index.html
+++ b/ThrustExpo/index.html
@@ -18,6 +18,7 @@
         <script src="../Libraries/ParameterMetadata.js"></script>
         <script src="../Libraries/FileSaver.js"></script>
         <script src="../Libraries/Array_Math.js"></script>
+        <script src="../Libraries/Param_Helpers.js"></script>
         <script src="ThrustExpo.js"></script>
     </head>
 
@@ -66,7 +67,8 @@
         </header>
 
         <div class="content">
-            <fieldset>
+            <table><tr><td>
+            <fieldset style="height:130px">
                 <legend>
                     Parameters
                     <img
@@ -161,8 +163,8 @@
                     </div>
                 </div>
             </fieldset>
-
-            <fieldset>
+            </td><td>
+            <fieldset style="height:130px">
                 <legend>
                     Hover Thrust Estimate
                     <img
@@ -188,11 +190,12 @@
                                 max="12"
                             />
                         </div>
-                        <div id="hover-thrust-estimate" class="param-row">
+                        <div class="param-row">
                             <input
                                 id="MOT_THST_HOVER"
                                 name="MOT_THST_HOVER"
                                 type="number"
+                                placeholder="?"
                                 disabled
                             />
                         </div>
@@ -214,6 +217,8 @@
                     </div>
                 </div>
             </fieldset>
+            </td></tr>
+            </table>
 
             <div id="thrust-table"></div>
 
@@ -224,4 +229,21 @@
             <div id="thrust-error-plot" class="thrust-plot"></div>
         </div>
     </body>
+    <script>
+
+        window.onerror = function(msg, url, linenumber) {
+            alert('Sorry, something went wrong.\n\n' + 
+                  'Please try a hard reload of this page to clear its cache.\n\n' +
+                  'If the error persists open an issue on the GitHub repo.\n' +
+                  'Include a copy of the log and the following error message:\n\n' +
+                   msg + '\n' +
+                  'URL: '+ url +'\n' +
+                  'Line Number: '+ linenumber)
+            return false
+        }
+        window.addEventListener('unhandledrejection', function (e) {
+          throw new Error(e.reason.stack)
+        })
+
+    </script>
 </html>

--- a/ThrustExpo/index.html
+++ b/ThrustExpo/index.html
@@ -68,7 +68,7 @@
 
         <div class="content">
             <table><tr><td>
-            <fieldset style="height:130px">
+            <fieldset>
                 <legend>
                     Parameters
                     <img
@@ -164,7 +164,7 @@
                 </div>
             </fieldset>
             </td><td>
-            <fieldset style="height:130px">
+            <fieldset>
                 <legend>
                     Hover Thrust Estimate
                     <img
@@ -174,7 +174,7 @@
                         data-tippy-maxWidth="750px"
                     />
                 </legend>
-                <div class="param-grid" style="padding-top: 0px">
+                <div class="param-grid">
                     <div class="param-column">
                         <div
                             class="param-row"


### PR DESCRIPTION
- This messes with the formatting a little, everything gets wider and param tables go side by side. Hover thrust is always shown.
![image](https://github.com/user-attachments/assets/a99b67b2-433c-429e-87de-5230fbfd7412)

This is really just a change to be more as I like it, also happy to not change it. 

- Fixes a few items missing on the reset call. If you hit example and then reset the spin arm/min/max lines remained The bottom plot was not cleared. 

- Adds the generic error catcher that pops a alert with info on how to report the issue.

- Use `param_to_string` from `Libraries/Param_Helpers.js` This limits the resolution of the saved params. For example of you click example and then save currently you get:
```
MOT_THST_EXPO,0.38500000000000106
```
Now you get:
```
MOT_THST_EXPO,0.385
```