### PR TITLE
HardwareReport: Clock Drift: make sure week and time of week are valid

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -2828,6 +2828,11 @@ async function load_log(log_file) {
                     continue
                 }
 
+                if ((weeks[i] <= 1000) || (ms[i] == 0)) {
+                    // Invalid timestamp
+                    continue
+                }
+
                 // Calculate GPS time in milli seconds
                 const ms_per_week = 7 * 24 * 60 * 60 * 1000
                 const GPS_ms = (weeks[i] * ms_per_week) + ms[i]


### PR DESCRIPTION
This could cause the refence point to be incorrect.

Before:

![image](https://github.com/user-attachments/assets/0b42519f-8637-48e9-9906-371bc6f1a385)

After:

![image](https://github.com/user-attachments/assets/2568df56-e296-4186-ab29-5022441529c1)
