### PR TITLE
FilterReview: RPMTarget: fix handling of new log format

### DIFF
--- a/FilterReview/tracking/RPM.js
+++ b/FilterReview/tracking/RPM.js
@@ -12,7 +12,7 @@ class RPMTarget extends NotchTarget {
         if ("instances" in log.messageTypes.RPM) {
             // New instance RPM message
             const inst = instance - 1
-            if (inst in Object.keys(log.messageTypes.RPM.instances)) {
+            if (inst in log.messageTypes.RPM.instances) {
                 this.data.time = TimeUS_to_seconds(log.get_instance(msg_name, inst, "TimeUS"))
                 this.data.value = log.get_instance(msg_name, inst, "RPM")
 


### PR DESCRIPTION
This fixes a error in handling of the second RPM instance with the new peri-instance RPM logging in 4.6 +.