### PR TITLE
Analytic Tune:  Add more predictive capability

### DIFF
--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -896,7 +896,9 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
     var minus_one = [new Array(H_acft[0].length).fill(-1), new Array(H_acft[0].length).fill(0)]
     const Ret_DRB = complex_div(minus_one, rate_INS_ANGP_plus_one)
    
-    return [Ret_rate, Ret_att_ff, Ret_pilot, Ret_DRB, Ret_att_nff]
+    const Ret_att_bl = rate_INS_ANGP
+
+    return [Ret_rate, Ret_att_ff, Ret_pilot, Ret_DRB, Ret_att_nff, Ret_att_bl]
 
 }
 
@@ -1360,7 +1362,8 @@ function calculate_freq_resp() {
     var H_att_ff_pred
     var H_pilot_pred
     var H_DRB_pred
-    [H_rate_pred, H_att_ff_pred, H_pilot_pred, H_DRB_pred, H_att_nff_pred] = calculate_predicted_TF(H_acft_tf, sample_rate, window_size)
+    var H_att_bl
+    [H_rate_pred, H_att_ff_pred, H_pilot_pred, H_DRB_pred, H_att_nff_pred, H_att_bl] = calculate_predicted_TF(H_acft_tf, sample_rate, window_size)
 
     calc_freq_resp = {
         pilotctrl_H: H_pilot_tf,
@@ -1380,7 +1383,8 @@ function calculate_freq_resp() {
         ratectrl_H: H_rate_pred,
         pilotctrl_H: H_pilot_pred,
         attctrl_nff_H: H_att_nff_pred,
-        DRB_H: H_DRB_pred
+        DRB_H: H_DRB_pred,
+        attbl_H: H_att_bl
     }
 
     redraw_freq_resp()
@@ -1847,10 +1851,14 @@ function redraw_freq_resp() {
     } else if (document.getElementById("type_Att_Ctrlr").checked) {
         calc_data = calc_freq_resp.attctrl_H
         calc_data_coh = calc_freq_resp.attctrl_coh
-        pred_data = pred_freq_resp.attctrl_nff_H
-//        calc_data = calc_freq_resp.DRB_H
-//        calc_data_coh = calc_freq_resp.DRB_coh
-//        pred_data = pred_freq_resp.DRB_H
+        pred_data = pred_freq_resp.attctrl_ff_H  // attitude controller with feedforward
+//        pred_data = pred_freq_resp.attctrl_nff_H  // attitude controller without feedforward
+
+//        calc_data = calc_freq_resp.DRB_H  // calculated disturbance rejection
+//        calc_data_coh = calc_freq_resp.DRB_coh  // calculated disturbance rejection coherence
+//        pred_data = pred_freq_resp.DRB_H  // predicted disturbance rejection
+
+//        pred_data = pred_freq_resp.attbl_H  // attitude stability
         pred_data_coh = calc_freq_resp.bareAC_coh
         show_set = true
     } else if (document.getElementById("type_Rate_Ctrlr").checked) {

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1159,7 +1159,6 @@ function load_log(log_file) {
         document.getElementById("endtime").value = end_time
     }
 
-    console.log(param)
     setup_FFT_data()
 }
 
@@ -1343,7 +1342,7 @@ function calculate_freq_resp() {
                   window_size: window_size,
                   correction: win_correction })
 
-    console.log(data_set)
+//    console.log(data_set)
 
     // Windowing amplitude correction depends on spectrum of interest and resolution
     const FFT_resolution = data_set.FFT.average_sample_rate/data_set.FFT.window_size
@@ -1355,7 +1354,7 @@ function calculate_freq_resp() {
 
     // Number of windows averaged
     const mean_length = end_index - start_index
-    console.log(mean_length)
+//    console.log(mean_length)
 
     var H_pilot
     var coh_pilot
@@ -1470,18 +1469,18 @@ function load_time_history_data(t_start, t_end, axis) {
     let timeRATE_arr = log.get("RATE", "TimeUS")
     const ind1_i = nearestIndex(timeRATE_arr, t_start*1000000)
     const ind2_i = nearestIndex(timeRATE_arr, t_end*1000000)
-    console.log("ind1: ",ind1_i," ind2: ",ind2_i)
+//    console.log("ind1: ",ind1_i," ind2: ",ind2_i)
 
     let timeRATE = Array.from(timeRATE_arr)
-    console.log("time field pre slicing size: ", timeRATE.length)
+//    console.log("time field pre slicing size: ", timeRATE.length)
 
     timeRATE = timeRATE.slice(ind1_i, ind2_i)
-    console.log("time field post slicing size: ", timeRATE.length)
+//    console.log("time field post slicing size: ", timeRATE.length)
 
     // Determine average sample rate
     const trecord = (timeRATE[timeRATE.length - 1] - timeRATE[0]) / 1000000
     const samplerate = (timeRATE.length)/ trecord
-    console.log("sample rate: ", samplerate)
+//    console.log("sample rate: ", samplerate)
 
     const timeATT = log.get("ATT", "TimeUS")
     const ind1_a = nearestIndex(timeATT, t_start*1000000)
@@ -1682,43 +1681,6 @@ function window_size_inc(event) {
     last_window_size = event.target.value
 }
 
-// build url and query string for current view and copy to clipboard
-function get_link() {
-
-    if (!(navigator && navigator.clipboard && navigator.clipboard.writeText)) {
-        // copy not available
-        return
-    }
-
-    // get base url
-    var url =  new URL((window.location.href).split('?')[0]);
-
-    // Add all query strings
-    var sections = ["params", "PID_params"];
-    for (var j = 0; j<sections.length; j++) {
-        var items = document.forms[sections[j]].querySelectorAll('input,select');
-        for (var i=-0;i<items.length;i++) {
-            if (items[i].name === "") {
-                // Invalid name
-                continue
-            }
-            if (items[i].type == "radio" && !items[i].checked) {
-                // Only add checked radio buttons
-                continue;
-            }
-            if (items[i].type == "checkbox") {
-                url.searchParams.append(items[i].name, items[i].checked);
-                continue;
-            }
-            url.searchParams.append(items[i].name, items[i].value);
-        }
-    }
-
-    // copy to clipboard
-    navigator.clipboard.writeText(url.toString());
-
-}
-
 function save_parameters() {
 
     function save_from_elements(inputs) {
@@ -1728,6 +1690,10 @@ function save_parameters() {
         for (const v in inputs) {
             var name = "" + inputs[v].id;
             if (document.getElementById('type_Roll').checked) {
+                if (name.startsWith("ATC_INPUT_")) {
+                    var value = inputs[v].value;
+                    params += name + "," + param_to_string(value) + "\n";
+                }
                 if (name.startsWith("ATC_RAT_RLL")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
@@ -1739,6 +1705,10 @@ function save_parameters() {
                 NEF_num = document.getElementById('ATC_RAT_RLL_NEF').value
                 NTF_num = document.getElementById('ATC_RAT_RLL_NTF').value
             } else if (document.getElementById('type_Pitch').checked) {
+                if (name.startsWith("ATC_INPUT_")) {
+                    var value = inputs[v].value;
+                    params += name + "," + param_to_string(value) + "\n";
+                }
                 if (name.startsWith("ATC_RAT_PIT")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
@@ -1750,7 +1720,11 @@ function save_parameters() {
                 NEF_num = document.getElementById('ATC_RAT_PIT_NEF').value
                 NTF_num = document.getElementById('ATC_RAT_PIT_NTF').value
             } else if (document.getElementById('type_Yaw').checked) {
-                if (name.startsWith("ATC_RAT_YAW")) {
+                if (name.startsWith("PILOT_")) {
+                    var value = inputs[v].value;
+                    params += name + "," + param_to_string(value) + "\n";
+                }
+                    if (name.startsWith("ATC_RAT_YAW")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
@@ -1760,14 +1734,6 @@ function save_parameters() {
                 }
                 NEF_num = document.getElementById('ATC_RAT_YAW_NEF').value
                 NTF_num = document.getElementById('ATC_RAT_YAW_NTF').value
-            }
-            if (name.startsWith("ATC_INPUT_")) {
-                var value = inputs[v].value;
-                params += name + "," + param_to_string(value) + "\n";
-            }
-            if (name.startsWith("PILOT_")) {
-                var value = inputs[v].value;
-                params += name + "," + param_to_string(value) + "\n";
             }
             if (NEF_num > 0) {
                 if (name.startsWith("FILT" + NEF_num + "_")) {
@@ -1915,7 +1881,7 @@ function redraw_freq_resp() {
 
     var unwrap_ph = document.getElementById("PID_ScaleUnWrap").checked;
 
-    console.log(sid_axis)
+//    console.log(sid_axis)
     unwrap_ph = false
      // Set scaled x data
     const scaled_bins = frequency_scale.fun(calc_freq_resp.freq)

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1908,22 +1908,13 @@ function redraw_freq_resp() {
     if (document.getElementById("type_Pilot_Ctrlr").checked) {
         calc_data = calc_freq_resp.pilotctrl_H
         calc_data_coh = calc_freq_resp.pilotctrl_coh
-        if (sid_axis > 2 && sid_axis < 7) {
+        if (sid_axis > 3) {
             show_set_calc = false
         }
         pred_data = pred_freq_resp.pilotctrl_H
         pred_data_coh = calc_freq_resp.bareAC_coh
         show_set_pred = true
-    } else if (document.getElementById("type_Att_Stab").checked) {
-        calc_data = calc_freq_resp.sysbl_H  // entire control system stability
-        calc_data_coh = calc_freq_resp.sysbl_coh
-        if (sid_axis < 10 || sid_axis > 12) {
-            show_set_calc = false
-        }
-        pred_data = pred_freq_resp.attbl_H  // attitude stability
-        pred_data_coh = calc_freq_resp.bareAC_coh
-        show_set_pred = true
-    } else if (document.getElementById("type_Rate_Stab").checked) {
+    } else if (document.getElementById("type_Sys_Stab").checked) {
         calc_data = calc_freq_resp.sysbl_H  // entire control system stability
         calc_data_coh = calc_freq_resp.sysbl_coh
         if (sid_axis < 10 || sid_axis > 12) {
@@ -1932,10 +1923,24 @@ function redraw_freq_resp() {
         pred_data = pred_freq_resp.sysbl_H  // attitude stability
         pred_data_coh = calc_freq_resp.bareAC_coh
         show_set_pred = true
+    } else if (document.getElementById("type_Att_Stab").checked) {
+        calc_data = calc_freq_resp.sysbl_H  // entire control system stability
+        calc_data_coh = calc_freq_resp.sysbl_coh
+        show_set_calc = false
+        pred_data = pred_freq_resp.attbl_H  // attitude stability
+        pred_data_coh = calc_freq_resp.bareAC_coh
+        show_set_pred = true
+    } else if (document.getElementById("type_Rate_Stab").checked) {
+        calc_data = calc_freq_resp.sysbl_H  // entire control system stability
+        calc_data_coh = calc_freq_resp.sysbl_coh
+        show_set_calc = false
+        pred_data = pred_freq_resp.ratebl_H  // attitude stability
+        pred_data_coh = calc_freq_resp.bareAC_coh
+        show_set_pred = true
     } else if (document.getElementById("type_Att_DRB").checked) {
         calc_data = calc_freq_resp.DRB_H  // calculated disturbance rejection
         calc_data_coh = calc_freq_resp.DRB_coh  // calculated disturbance rejection coherence
-        if (sid_axis < 3 || sid_axis > 6) {
+        if (sid_axis < 4 || sid_axis > 6) {
             show_set_calc = false
         }
         pred_data = pred_freq_resp.DRB_H  // predicted disturbance rejection
@@ -1944,7 +1949,7 @@ function redraw_freq_resp() {
     } else if (document.getElementById("type_Att_Ctrlr_nff").checked) {
         calc_data = calc_freq_resp.attctrl_H
         calc_data_coh = calc_freq_resp.attctrl_coh
-        if (sid_axis < 3 || sid_axis > 6) {
+        if (sid_axis < 4 || sid_axis > 6) {
             show_set_calc = false
         }
         pred_data = pred_freq_resp.attctrl_nff_H  // attitude controller without feedforward
@@ -1953,7 +1958,7 @@ function redraw_freq_resp() {
     } else if (document.getElementById("type_Att_Ctrlr").checked) {
         calc_data = calc_freq_resp.attctrl_H
         calc_data_coh = calc_freq_resp.attctrl_coh
-        if (sid_axis > 2 && sid_axis < 7) {
+        if (sid_axis > 3 && sid_axis < 7 || sid_axis > 9) {
             show_set_calc = false
         }
         pred_data = pred_freq_resp.attctrl_ff_H  // attitude controller with feedforward
@@ -1962,7 +1967,9 @@ function redraw_freq_resp() {
     } else if (document.getElementById("type_Rate_Ctrlr").checked) {
         calc_data = calc_freq_resp.ratectrl_H
         calc_data_coh = calc_freq_resp.ratectrl_coh
-        show_set_calc = true
+        if (sid_axis > 9) {
+            show_set_calc = false
+        }
         pred_data = pred_freq_resp.ratectrl_H
         pred_data_coh = calc_freq_resp.bareAC_coh
         show_set_pred = true

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1045,16 +1045,16 @@ function load_log(log_file) {
         for (let k=1;k<SIDD_time.length;k++) {
             if (SIDD_time[k]-SIDD_time[k-1] > 0.5) {
                 sid_sets.tend[j] = SIDD_time[k-1]
-                if (sid_sets.tend[j]-sid_sets.tstart[j] > sid_sets.tlen[j]) {
-                    sid_sets.tend[j]=sid_sets.tstart[j]+sid_sets.tlen[j]
+                if (sid_sets.tend[j]-sid_sets.tstart[j] > sid_sets.tlen[j] + 1.0) {
+                    sid_sets.tend[j]=sid_sets.tstart[j]+sid_sets.tlen[j] + 1.0
                 }
                 j++
                 sid_sets.tstart[j] = SIDD_time[k]
             }
         }
         sid_sets.tend[j] = SIDD_time[SIDD_time.length-1]
-        if (sid_sets.tend[j]-sid_sets.tstart[j] > sid_sets.tlen[j]) {
-            sid_sets.tend[j]=sid_sets.tstart[j]+sid_sets.tlen[j]
+        if (sid_sets.tend[j]-sid_sets.tstart[j] > sid_sets.tlen[j] + 1.0) {
+            sid_sets.tend[j]=sid_sets.tstart[j]+sid_sets.tlen[j] + 1.0
         }
         start_time = sid_sets.tstart[0]
         end_time = sid_sets.tend[0]

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -886,7 +886,12 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
 
     // calculate transfer function for pilot feel LPF
     var tc_filter = []
-    const tc_freq = 1 / (get_form("ATC_INPUT_TC") * 2 * Math.PI)
+    var tc_freq
+    if (get_axis_prefix() == "YAW_") {
+        tc_freq = 1 / (get_form("PILOT_Y_RATE_TC") * 2 * Math.PI)
+    } else {
+        tc_freq = 1 / (get_form("ATC_INPUT_TC") * 2 * Math.PI)
+    }
     tc_filter.push(new LPF_1P(PID_rate, tc_freq))
     const tc_H = evaluate_transfer_functions([tc_filter], freq_max, freq_step, use_dB, unwrap_phase)
     // calculate transfer function for pilot input to the aircraft response
@@ -1115,6 +1120,7 @@ function load_log(log_file) {
     const other_params = [
         "INS_GYRO_FILTER",
         "ATC_INPUT_TC",
+        "PILOT_Y_RATE_TC",
         "ATC_ANG_RLL_P",
         "ATC_ANG_PIT_P",
         "ATC_ANG_YAW_P"
@@ -1153,6 +1159,7 @@ function load_log(log_file) {
         document.getElementById("endtime").value = end_time
     }
 
+    console.log(param)
     setup_FFT_data()
 }
 
@@ -1237,6 +1244,8 @@ function axis_changed() {
 }
 
 function update_PID_filters() {
+    document.getElementById('RollPitchTC').style.display = 'none';
+    document.getElementById('YawTC').style.display = 'none';
     document.getElementById('RollPIDS').style.display = 'none';
     document.getElementById('PitchPIDS').style.display = 'none';
     document.getElementById('YawPIDS').style.display = 'none';
@@ -1247,6 +1256,7 @@ function update_PID_filters() {
         document.getElementById('FILT' + i).style.display = 'none';
     }
     if (document.getElementById('type_Roll').checked) {
+        document.getElementById('RollPitchTC').style.display = 'block';
         document.getElementById('RollPIDS').style.display = 'block';;
         document.getElementById('RollNOTCH').style.display = 'block';
         const NTF_num = document.getElementById('ATC_RAT_RLL_NTF').value;
@@ -1258,6 +1268,7 @@ function update_PID_filters() {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
     } else if (document.getElementById('type_Pitch').checked) {
+        document.getElementById('RollPitchTC').style.display = 'block';
         document.getElementById('PitchPIDS').style.display = 'block';
         document.getElementById('PitchNOTCH').style.display = 'block';
         const NTF_num = document.getElementById('ATC_RAT_PIT_NTF').value;
@@ -1269,6 +1280,7 @@ function update_PID_filters() {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
     } else if (document.getElementById('type_Yaw').checked) {
+        document.getElementById('YawTC').style.display = 'block';
         document.getElementById('YawPIDS').style.display = 'block';
         document.getElementById('YawNOTCH').style.display = 'block';
         const NTF_num = document.getElementById('ATC_RAT_YAW_NTF').value;
@@ -1748,6 +1760,14 @@ function save_parameters() {
                 }
                 NEF_num = document.getElementById('ATC_RAT_YAW_NEF').value
                 NTF_num = document.getElementById('ATC_RAT_YAW_NTF').value
+            }
+            if (name.startsWith("ATC_INPUT_")) {
+                var value = inputs[v].value;
+                params += name + "," + param_to_string(value) + "\n";
+            }
+            if (name.startsWith("PILOT_")) {
+                var value = inputs[v].value;
+                params += name + "," + param_to_string(value) + "\n";
             }
             if (NEF_num > 0) {
                 if (name.startsWith("FILT" + NEF_num + "_")) {

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -898,7 +898,9 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
    
     const Ret_att_bl = rate_INS_ANGP
 
-    return [Ret_rate, Ret_att_ff, Ret_pilot, Ret_DRB, Ret_att_nff, Ret_att_bl]
+    const Ret_rate_bl = INS_PID_Acft
+
+    return [Ret_rate, Ret_att_ff, Ret_pilot, Ret_DRB, Ret_att_nff, Ret_att_bl, Ret_rate_bl]
 
 }
 
@@ -1367,7 +1369,8 @@ function calculate_freq_resp() {
     var H_pilot_pred
     var H_DRB_pred
     var H_att_bl
-    [H_rate_pred, H_att_ff_pred, H_pilot_pred, H_DRB_pred, H_att_nff_pred, H_att_bl] = calculate_predicted_TF(H_acft_tf, sample_rate, window_size)
+    var H_rate_bl
+    [H_rate_pred, H_att_ff_pred, H_pilot_pred, H_DRB_pred, H_att_nff_pred, H_att_bl, H_rate_bl] = calculate_predicted_TF(H_acft_tf, sample_rate, window_size)
 
     calc_freq_resp = {
         pilotctrl_H: H_pilot_tf,
@@ -1388,7 +1391,8 @@ function calculate_freq_resp() {
         pilotctrl_H: H_pilot_pred,
         attctrl_nff_H: H_att_nff_pred,
         DRB_H: H_DRB_pred,
-        attbl_H: H_att_bl
+        attbl_H: H_att_bl,
+        ratebl_H: H_rate_bl
     }
 
     redraw_freq_resp()
@@ -1862,6 +1866,13 @@ function redraw_freq_resp() {
         calc_data_coh = calc_freq_resp.attctrl_coh
         show_set_calc = false
         pred_data = pred_freq_resp.attbl_H  // attitude stability
+        pred_data_coh = calc_freq_resp.bareAC_coh
+        show_set_pred = true
+    } else if (document.getElementById("type_Rate_Stab").checked) {
+        calc_data = calc_freq_resp.attctrl_H
+        calc_data_coh = calc_freq_resp.attctrl_coh
+        show_set_calc = false
+        pred_data = pred_freq_resp.ratebl_H  // attitude stability
         pred_data_coh = calc_freq_resp.bareAC_coh
         show_set_pred = true
     } else if (document.getElementById("type_Att_DRB").checked) {

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -2163,7 +2163,8 @@ function set_sid_axis(axis) {
     } else if (axis == 2 || axis == 5 || axis == 8 || axis == 11) {
         document.getElementById("type_Pitch").checked = true
     } else if (axis == 3 || axis == 6 || axis == 9 || axis == 12) {
-        document.getElementById("type_Pitch").checked = true
+        document.getElementById("type_Yaw").checked = true
     }
     sid_axis = axis
+    axis_changed()
 }

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -990,6 +990,7 @@ function TimeUS_to_seconds(TimeUS) {
 let log
 var sid_axis
 var sid_sets = {}
+var use_ANG_message
 function load_log(log_file) {
 
     log = new DataflashParser()
@@ -1071,6 +1072,14 @@ function load_log(log_file) {
         flight_data.data[3].y = log.get("RATE", "Y")
         update_time(RATE_time)
     }
+
+    // Determine if ANG message is used instead of ATT message
+    if ("ANG" in log.messageTypes) {
+        use_ANG_message = true
+    } else {
+        use_ANG_message = false
+    }
+
 
     // If found use zoom to non-zero SIDD
     if ((start_time != null) && (end_time != null)) {
@@ -1482,9 +1491,18 @@ function load_time_history_data(t_start, t_end, axis) {
     const samplerate = (timeRATE.length)/ trecord
 //    console.log("sample rate: ", samplerate)
 
-    const timeATT = log.get("ATT", "TimeUS")
-    const ind1_a = nearestIndex(timeATT, t_start*1000000)
-    const ind2_a = nearestIndex(timeATT, t_end*1000000)
+    var timeATT
+    var ind1_a
+    var ind2_a
+    if (use_ANG_message) {
+        timeATT = log.get("ANG", "TimeUS")
+        ind1_a = nearestIndex(timeATT, t_start*1000000)
+        ind2_a = nearestIndex(timeATT, t_end*1000000)
+    } else {
+        timeATT = log.get("ATT", "TimeUS")
+        ind1_a = nearestIndex(timeATT, t_start*1000000)
+        ind2_a = nearestIndex(timeATT, t_end*1000000)
+    }
 
     const timeSIDD = log.get("SIDD", "TimeUS")
     const ind1_s = nearestIndex(timeSIDD, t_start*1000000)
@@ -1521,8 +1539,15 @@ function load_time_history_data(t_start, t_end, axis) {
     let ActInputData = Array.from(log.get("RATE", ActInputParam))
     let RateTgtData = Array.from(log.get("RATE", RateTgtParam))
     let RateData = Array.from(log.get("RATE", RateParam))
-    let AttTgtData = Array.from(log.get("ATT", AttTgtParam))
-    let AttData = Array.from(log.get("ATT", AttParam))
+    var AttTgtData
+    var AttData
+    if (use_ANG_message) {
+        AttTgtData = Array.from(log.get("ANG", AttTgtParam))
+        AttData = Array.from(log.get("ANG", AttParam))
+    } else {
+        AttTgtData = Array.from(log.get("ATT", AttTgtParam))
+        AttData = Array.from(log.get("ATT", AttParam))
+    }
     let GyroRawData = Array.from(log.get("SIDD", GyroRawParam))
 
     // Slice ActInputData

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -586,12 +586,8 @@
   calc_btn.onclick = function() {
       calculate_freq_resp();
   }
-  //var clear_btn = document.getElementById('clear_cookies');
-  //clear_btn.onclick = function() {
-  //    clear_cookies();
-  //}
 
-  let params = ["SCHED_LOOP_RATE"]
+  let params = ["SCHED_LOOP_RATE", "PILOT_Y_RATE_TC"]
   var inputs = document.getElementsByTagName("input");
   for (param of inputs) {
       if (param.id.startsWith("INS_") || param.id.startsWith("ATC_") || param.id.startsWith("FILT")) {

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -479,14 +479,20 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <fieldset style="width:200px;height:90px">
+                                                <fieldset style="width:300px;height:150px">
                                                         <legend>Control Loop</legend>
                                                         <input type="radio" id="type_Bare_AC" name="Control_Loop" value="Bare_AC"  onchange="redraw_freq_resp();">
                                                         <label for="type_Bare_AC">Bare Aircraft</label><br>
                                                         <input type="radio" id="type_Rate_Ctrlr" name="Control_Loop" value="Rate_Ctrlr"  onchange="redraw_freq_resp();" checked>
                                                         <label for="type_Rate_Ctrlr">Rate Controller</label><br>
                                                         <input type="radio" id="type_Att_Ctrlr" name="Control_Loop" value="Att_Ctrlr"  onchange="redraw_freq_resp();">
-                                                        <label for="type_Att_Ctrlr">Attitude Controller</label><br>
+                                                        <label for="type_Att_Ctrlr">Attitude Controller with Feedforward</label><br>
+                                                        <input type="radio" id="type_Att_Ctrlr_nff" name="Control_Loop" value="Att_Ctrlr_nff"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Att_Ctrlr_nff">Attitude Controller without feedforward</label><br>
+                                                        <input type="radio" id="type_Att_DRB" name="Control_Loop" value="Att_DRB"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Att_DRB">Attitude Disturbance Rejection</label><br>
+                                                        <input type="radio" id="type_Att_Stab" name="Control_Loop" value="Att_Stab"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Att_Stab">Attitude Stability</label><br>
                                                         <input type="radio" id="type_Pilot_Ctrlr" name="Control_Loop" value="Pilot_Ctrlr"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_Ctrlr">Input Shaping</label><br>
                                                 </fieldset>

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -208,10 +208,17 @@
         <tr>
         <td>
         <fieldset style="width:580px">
-                <legend>Attitude Controller Parameters</legend>
-                        <p>
-                                <input id="ATC_INPUT_TC" name="ATC_INPUT_TC" type="number" step="0.01" value="0.15" onchange = "calculate_freq_resp()"/>
-                        </p>
+                <legend>Attitude Controller Parameters **WARNING - Parameter values are not updated if they changed during the log**</legend>
+                        <div id="RollPitchTC" style="display:block">
+                                <p>
+                                        <input id="ATC_INPUT_TC" name="ATC_INPUT_TC" type="number" step="0.01" value="0.15" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
+                        <div id="YawTC" style="display:None">
+                                <p>
+                                        <input id="PILOT_Y_RATE_TC" name="PILOT_Y_RATE_TC" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="RollPIDS" style="display:block">
                                 <p>
                                         <input id="ATC_ANG_RLL_P" name="ATC_ANG_RLL_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -479,7 +479,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <fieldset style="width:300px;height:150px">
+                                                <fieldset style="width:300px;height:170px">
                                                         <legend>Control Loop</legend>
                                                         <input type="radio" id="type_Bare_AC" name="Control_Loop" value="Bare_AC"  onchange="redraw_freq_resp();">
                                                         <label for="type_Bare_AC">Bare Aircraft</label><br>
@@ -491,6 +491,8 @@
                                                         <label for="type_Att_Ctrlr_nff">Attitude Controller without feedforward</label><br>
                                                         <input type="radio" id="type_Att_DRB" name="Control_Loop" value="Att_DRB"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_DRB">Attitude Disturbance Rejection</label><br>
+                                                        <input type="radio" id="type_Rate_Stab" name="Control_Loop" value="Rate_Stab"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Rate_Stab">Rate Stability</label><br>
                                                         <input type="radio" id="type_Att_Stab" name="Control_Loop" value="Att_Stab"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_Stab">Attitude Stability</label><br>
                                                         <input type="radio" id="type_Pilot_Ctrlr" name="Control_Loop" value="Pilot_Ctrlr"  onchange="redraw_freq_resp();">

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -491,7 +491,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <fieldset style="width:300px;height:170px">
+                                                <fieldset style="width:300px;height:200px">
                                                         <legend>Control Loop</legend>
                                                         <input type="radio" id="type_Bare_AC" name="Control_Loop" value="Bare_AC"  onchange="redraw_freq_resp();">
                                                         <label for="type_Bare_AC">Bare Aircraft</label><br>
@@ -501,14 +501,16 @@
                                                         <label for="type_Att_Ctrlr">Attitude Controller with Feedforward</label><br>
                                                         <input type="radio" id="type_Att_Ctrlr_nff" name="Control_Loop" value="Att_Ctrlr_nff"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_Ctrlr_nff">Attitude Controller without feedforward</label><br>
+                                                        <input type="radio" id="type_Pilot_Ctrlr" name="Control_Loop" value="Pilot_Ctrlr"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Att_Ctrlr">Input Shaping</label><br>
                                                         <input type="radio" id="type_Att_DRB" name="Control_Loop" value="Att_DRB"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_DRB">Attitude Disturbance Rejection</label><br>
                                                         <input type="radio" id="type_Rate_Stab" name="Control_Loop" value="Rate_Stab"  onchange="redraw_freq_resp();">
                                                         <label for="type_Rate_Stab">Rate Stability</label><br>
                                                         <input type="radio" id="type_Att_Stab" name="Control_Loop" value="Att_Stab"  onchange="redraw_freq_resp();">
                                                         <label for="type_Att_Stab">Attitude Stability</label><br>
-                                                        <input type="radio" id="type_Pilot_Ctrlr" name="Control_Loop" value="Pilot_Ctrlr"  onchange="redraw_freq_resp();">
-                                                        <label for="type_Att_Ctrlr">Input Shaping</label><br>
+                                                        <input type="radio" id="type_Sys_Stab" name="Control_Loop" value="Sys_Stab"  onchange="redraw_freq_resp();">
+                                                        <label for="type_Sys_Stab">Entire System Stability</label><br>
                                                 </fieldset>
                                         </td>
                                         <td>

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -90,6 +90,18 @@
         </td>
         </tr>
 </table>
+<table>
+<tr>
+        <td style="width: 30px;"></td>
+        <td>
+                <fieldset style="width:600px; min-height:300px" id="sid_sets">
+                    <legend>System ID Runs</legend>
+                </fieldset>
+        </td>
+        </tr>
+
+</table>
+
             
 <table><tr><td style="width:1200px">
 <h2 style="text-align:center">Flight Data</h2>

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -114,10 +114,11 @@
   <input type="button" id="SaveParams" value="Save Parameters" onclick="save_parameters();">
   <button class="styleClass" onclick="document.getElementById('param_file').click()">Load Parameters</button>
   <input type='file' id="param_file" style="display:none" onchange="load_parameters(this.files[0]);">
-  <input type="button" id="GetLink" value="Get Link" onclick="get_link();">
 </p>
 
-  <form id="params" action="">
+<h2><label id="warning">WARNING - Parameter values are not updated if they changed during the log. If parameters were changed during the flight, be sure to verify the values below.</label></h2>
+
+<form id="params" action="">
 
 <fieldset style="max-width:1200px">
   <legend>INS Settings</legend>
@@ -208,7 +209,7 @@
         <tr>
         <td>
         <fieldset style="width:580px">
-                <legend>Attitude Controller Parameters **WARNING - Parameter values are not updated if they changed during the log**</legend>
+                <legend>Attitude Controller Parameters</legend>
                         <div id="RollPitchTC" style="display:block">
                                 <p>
                                         <input id="ATC_INPUT_TC" name="ATC_INPUT_TC" type="number" step="0.01" value="0.15" onchange = "calculate_freq_resp()"/>

--- a/AnalyticTune/params.json
+++ b/AnalyticTune/params.json
@@ -729,6 +729,19 @@
       "__field_text": "\n    // @DisplayName: Throttle Mix Minimum\n    // @Description: Throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.1 0.25\n    // @User: Advanced"
     }
   },
+  "PILOT": {
+    "PILOT_Y_RATE_TC": {
+      "Description": "Pilot yaw rate control input time constant",
+      "DisplayName": "Pilot yaw rate control input time constant",
+      "Range": {
+        "high": "0.5",
+        "low": "0.01"
+      },
+      "Units": "s",
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Pilot yaw rate control input time constant\n    // @Description: Pilot yaw rate control input time constant\n    // @Range: 0.01 0.5\n   // @User: Advanced"
+    }
+  },
   "INS": {
     "INS_ACC1_CALTEMP": {
       "Calibration": "1",


### PR DESCRIPTION
This PR contains the additional calculations to determine predicted attitude Disturbance Rejection Bandwidth, attitude control with no feedforward path, and attitude stability (broken loop).  A calculation was also added for attitude control without feedforward path.  
This is all available to be plotted.  just need to add the plotting options.
I think the attitude control with and without feedforward should be set based on the SID axis. SID axes 1,2, and 3 would use the calculated and predicted attitude control with feedforward.  SID axes 4, 5 and 6 would use the calculated and predicted attitude control with no feedforward.

The predicted DRB and predicted stability should be available to display with any SID axis selected.

The calculated DRB is only available when SID Axes 4, 5, and 6 are selected.

@IamPete1 and @lthall I think these are the maths you need to put the rest of the tool together.  Let me know if you need anything.