### PR TITLE
AnalytictTune: a couple of fixups 

### DIFF
--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -647,6 +647,21 @@ var flight_data = {}
 var fft_plot = {}
 var fft_plot_Phase = {}
 var fft_plot_Coh = {}
+
+function link_plots() {
+
+    // Link all frequency axis
+    link_plot_axis_range([["FFTPlotMag", "x", "", fft_plot],
+                          ["FFTPlotPhase", "x", "", fft_plot_Phase],
+                          ["FFTPlotCoh", "x", "", fft_plot_Coh]])
+
+    // Link all reset calls
+    link_plot_reset([["FFTPlotMag", fft_plot],
+                     ["FFTPlotPhase", fft_plot_Phase],
+                     ["FFTPlotCoh", fft_plot_Coh]])
+
+}
+
 function setup_plots() {
 
     const time_scale_label = "Time (s)"
@@ -766,7 +781,7 @@ function setup_plots() {
     Plotly.purge(plot)
     Plotly.newPlot(plot, fft_plot_Coh.data, fft_plot_Coh.layout, {displaylogo: false});
 
-    //link_plots()
+    link_plots()
 }
 
 function get_axis_prefix() {
@@ -1224,7 +1239,7 @@ function setup_FFT_data() {
     Plotly.purge(plot)
     Plotly.newPlot(plot, fft_plot_Coh.data, fft_plot_Coh.layout, {displaylogo: false});
 
-//    link_plots()
+    link_plots()
 
 }
 

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -2084,9 +2084,14 @@ function add_sid_sets() {
     let header = document.createElement("tr")
     table.appendChild(header)
 
-    function set_cell_style(cell, color) {
+    function set_cell_style(cell, color, center) {
         cell.style.border = "1px solid #000"
         cell.style.padding = "8px"
+
+        if (center !== false) {
+            cell.style.textAlign = "center"
+        }
+
         if (color != null) {
             // add alpha, 40%
             cell.style.backgroundColor = color + '66'
@@ -2118,47 +2123,88 @@ function add_sid_sets() {
     item.appendChild(document.createTextNode("End Time"))
     set_cell_style(item)
 
-    var num_sets = sid_sets.axis.length
+    const axisTypes = {
+       1: "Input Roll Angle",
+       2: "Input Pitch Angle",
+       3: "Input Yaw Angle",
+       4: "Recovery Roll Angle",
+       5: "Recovery Pitch Angle",
+       6: "Recovery Yaw Angle",
+       7: "Rate Roll",
+       8: "Rate Pitch",
+       9: "Rate Yaw",
+       10: "Mixer Roll",
+       11: "Mixer Pitch",
+       12: "Mixer Yaw",
+       13: "Mixer Thrust",
+       14: "Measured Lateral Position",
+       15: "Measured Longitudinal Position",
+       16: "Measured Lateral Velocity",
+       17: "Measured Longitudinal Velocity",
+       18: "Input Lateral Velocity",
+       19: "Input Longitudinal Velocity"
+    }
+
+    const num_sets = sid_sets.axis.length
     // Add line
-    let radio = document.createElement("input")
     for (let i = 0; i < num_sets; i++) {
         const color = num_sets > 1 ? plot_default_color(i) : null
 
+        // Add new row
         let row = document.createElement("tr")
         table.appendChild(row)
 
+        // Index
         let index = document.createElement("td")
         row.appendChild(index)
         set_cell_style(index, color)
         index.appendChild(document.createTextNode(i + 1))
 
+        // Use radio button
         let item = document.createElement("td")
         row.appendChild(item)
         set_cell_style(item, color)
 
-        radio = document.createElement("input")
+        let radio = document.createElement("input")
         radio.setAttribute('type', "radio")
         radio.setAttribute('id', "set_selection_" + i)
         radio.setAttribute('name', "sid_sets")
         radio.setAttribute('value', "set_set_" + i)
         radio.setAttribute('onchange', "update_time_range(this); time_range_changed(this)")
-        if (i == 0) {radio.checked = true}
         item.appendChild(radio)
 
-        item = document.createElement("td")
-        row.appendChild(item)
-        set_cell_style(item, color)
-        item.appendChild(document.createTextNode(sid_sets.axis[i]))
+        // Select first item by defualt
+        if (i == 0) {
+            radio.checked = true
+        }
 
+        // Axis
         item = document.createElement("td")
         row.appendChild(item)
-        set_cell_style(item, color)
-        item.appendChild(document.createTextNode(sid_sets.tstart[i]))
+        set_cell_style(item, color, false)
 
+        // Add type string
+        const axis = sid_sets.axis[i]
+        if (axis in axisTypes) {
+            // Number and type
+            item.appendChild(document.createTextNode(sid_sets.axis[i] + ": " + axisTypes[axis]))
+
+        } else {
+            // Number only
+            item.appendChild(document.createTextNode(sid_sets.axis[i]))
+        }
+
+        // Start time
         item = document.createElement("td")
         row.appendChild(item)
         set_cell_style(item, color)
-        item.appendChild(document.createTextNode(sid_sets.tend[i]))
+        item.appendChild(document.createTextNode(sid_sets.tstart[i].toFixed(2)))
+
+        // End time
+        item = document.createElement("td")
+        row.appendChild(item)
+        set_cell_style(item, color)
+        item.appendChild(document.createTextNode(sid_sets.tend[i].toFixed(2)))
 
     }
 }

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -61,7 +61,7 @@
                         </fieldset>
                 </td>
                 <td>
-                <fieldset style="width:200px;height:80px">
+                <fieldset style="width:100px;height:80px">
                         <legend>Axis</legend>
                         <input type="radio" id="type_Roll" name="Axis" checked onchange = "axis_changed()">
                         <label for="type_Roll">Roll</label><br>
@@ -75,9 +75,9 @@
                 <fieldset style="width:200px;height:80px">
                         <legend>Analysis time</legend>
                         <label for="starttime">Start (s)</label>
-                        <input id="starttime" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:50px"/><br><br>
+                        <input id="starttime" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:100px"/><br><br>
                         <label for="endtime">End (s)</label>
-                        <input id="endtime" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:50px"/>
+                        <input id="endtime" type="number" min="0" step="1" value="0" onchange="time_range_changed()" style="width:100px"/>
                 </fieldset>
                 </td>
                 <td style="width: 10px;"></td>


### PR DESCRIPTION
A couple of UI updates. 

- Sets get axis names and shorter times.

Before:
![image](https://github.com/user-attachments/assets/330ec18e-2d98-4a8f-a4e1-442a031f6de8)

After:
![image](https://github.com/user-attachments/assets/6985398f-239b-46f3-bd78-0cdeb0b0a84f)

- Top timestamps get a bit more room.
Before:
![image](https://github.com/user-attachments/assets/ae27a63d-c5ff-4abe-8a9f-55bc15c34eee)

After:
![image](https://github.com/user-attachments/assets/ff0c335d-1a24-435f-a4c7-466cf4df569e)

- This also links the frequency axis of the plots. So if you zoom on one plot the others update to match. 
