### PR TITLE
fixed implicit global variable in LogFinder.js

### DIFF
--- a/LogFinder/LogFinder.js
+++ b/LogFinder/LogFinder.js
@@ -637,7 +637,7 @@ function update_param_diff(table, rows) {
     rows[0].getData().param_diff = null
 
     // Calculate diff for each row
-    for (i = 1; i<rows.length; i++) {
+    for (let i = 1; i<rows.length; i++) {
         const param_diff = get_param_diff(rows[i].getData().info.params, rows[i-1].getData().info.params)
         rows[i].getData().param_diff = param_diff
     }


### PR DESCRIPTION
This PR resolves issue #232 by properly scoping the loop variable in LogFinder.js. 

The implicit global variable has been replaced with a let declaration.

