### PR TITLE
HardwareReport: Optimize canvas readback performance by setting willReadFrequently

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -12,6 +12,19 @@ import_done[1] = import('https://esm.sh/@octokit/request')
     .catch(error => console.log(error))
 
 
+function configurePlotlyCanvas() {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function(contextType, contextAttributes) {
+    if (contextType === '2d') {
+      contextAttributes = contextAttributes || {};
+      contextAttributes.willReadFrequently = true;
+    }
+    return originalGetContext.call(this, contextType, contextAttributes);
+  };
+}
+configurePlotlyCanvas()
+
+
 let ArduPilot_GitHub_tags
 let octokitRequest_ratelimit_reset
 async function check_release(hash, paragraph) {


### PR DESCRIPTION
This PR addresses issue #233. about a performance warning in the Hardware Report Tool related to frequent readback operations on a `<canvas>`.

To fix it I added a function `configurePlotlyCanvas()` in `HardwareReport.js`. This function overrides `HTMLCanvasElement.prototype.getContext` to ensure that when a 2d context is requested, the `willReadFrequently` attribute is always set to `true`.

To test it, I verified that the hardware report tool still functions correctly with a couple of log files I generated from SITL. I also confirmed that the console warning is no longer displayed.

Let me know if any adjustments are needed.


