### PR TITLE
FilterReview: Allow for negative RPMs

### DIFF
--- a/FilterReview/tracking/ESC.js
+++ b/FilterReview/tracking/ESC.js
@@ -112,7 +112,7 @@ class ESCTarget extends NotchTarget {
             return config.freq
         }
         if (get_filter_version() == 2) {
-            return freq
+            return Math.abs(freq)
         }
         return Math.max(freq, config.freq)
     }

--- a/FilterReview/tracking/FFT.js
+++ b/FilterReview/tracking/FFT.js
@@ -74,7 +74,7 @@ class FFTTarget extends NotchTarget {
             return config.freq
         }
         if (get_filter_version() == 2) {
-            return freq
+            return Math.abs(freq)
         }
         return Math.max(freq, config.freq)
     }

--- a/FilterReview/tracking/RPM.js
+++ b/FilterReview/tracking/RPM.js
@@ -42,7 +42,7 @@ class RPMTarget extends NotchTarget {
         const freq = rpm * config.ref * (1.0/60.0)
         if (get_filter_version() == 2) {
             if (rpm_valid) {
-                return freq
+                return Math.abs(freq)
             }
             return 0.0
         }

--- a/FilterReview/tracking/Static.js
+++ b/FilterReview/tracking/Static.js
@@ -7,17 +7,24 @@ class StaticTarget extends NotchTarget {
     // Don't need to interpolate static
     interpolate(instance, time) { }
 
+    get_target(config) {
+        if (get_filter_version() == 2) {
+            return Math.abs(config.freq)
+        }
+        return config.freq
+    }
+
     get_target_freq(config) {
-        return { freq:[config.freq, config.freq], time:[Gyro_batch.start_time, Gyro_batch.end_time] }
+        return { freq:[this.get_target(config), this.get_target(config)], time:[Gyro_batch.start_time, Gyro_batch.end_time] }
     }
 
     get_target_freq_time(config, time) {
         // Target is independent of time
-        return [config.freq]
+        return [this.get_target(config)]
     }
 
     get_interpolated_target_freq(instance, index, config) {
-        return [config.freq]
+        return [this.get_target(config)]
     }
 
     have_data(config) {

--- a/FilterReview/tracking/Throttle.js
+++ b/FilterReview/tracking/Throttle.js
@@ -332,7 +332,7 @@ class ThrottleTarget extends NotchTarget {
         const motors_throttle = Math.max(0, thrust)
         const throttle_norm = Math.sqrt(motors_throttle / config.ref)
         if (get_filter_version() == 2) {
-            return config.freq * throttle_norm
+            return Math.abs(config.freq * throttle_norm)
         }
         return config.freq * Math.max(config.min_ratio, throttle_norm)
     }


### PR DESCRIPTION
This is to bring the tool in-line with https://github.com/ArduPilot/ardupilot/pull/28309.

Currently, if an ESC reports negative RPMs, the filter will clip the ESC notches at `INS_HNTCH_FREQ`:
![Screenshot from 2025-04-07 19-14-15](https://github.com/user-attachments/assets/1f174a44-e7b1-4e5f-996e-f16082ce2471)

This PR allows the notches to track correctly again:
![Screenshot from 2025-04-07 19-16-33](https://github.com/user-attachments/assets/bfb5c44a-c083-4c66-a674-460acdfc36f2)

This is applied only as an option of 4.6 (v2 filters).