### PR TITLE
FilterReview: Throttle tracking: fix for no logged RCOutput

### DIFF
--- a/FilterReview/tracking/Throttle.js
+++ b/FilterReview/tracking/Throttle.js
@@ -3,6 +3,11 @@ class ThrottleTarget extends NotchTarget {
     constructor(log) {
         super(log, "RATE", "AOut", "Throttle", 1)
 
+        // Need RC outputs for per motor throttle notch
+        if (!("RCOU" in log.messageTypes)) {
+            return
+        }
+
         // Read params
         const PARM = log.get("PARM")
 


### PR DESCRIPTION
Don't try and populate per motor throttle tracking if there is no logged RC outputs.

Fixes https://github.com/ArduPilot/WebTools/issues/246
