### PR TITLE
Allow Analytic Tune to be used with Quadplanes

### DIFF
--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -812,7 +812,7 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
 
     // Calculate transfer function for Rate PID
     var PID_filter = []
-    var axis_prefix = "ATC_RAT_" + get_axis_prefix();
+    var axis_prefix = get_vehicle_att_prefix() + "RAT_" + get_axis_prefix();
     PID_filter.push(new PID(PID_rate,
         get_form(axis_prefix + "P"),
         get_form(axis_prefix + "I"),
@@ -886,7 +886,7 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
 
     // calculate transfer function for the angle P in prep for attitude controller calculation
     var Ang_P_filter = []
-    Ang_P_filter.push(new Ang_P(PID_rate, get_form("ATC_ANG_" + get_axis_prefix() + "P")))
+    Ang_P_filter.push(new Ang_P(PID_rate, get_form(get_vehicle_att_prefix() + "ANG_" + get_axis_prefix() + "P")))
     const Ang_P_H = evaluate_transfer_functions([Ang_P_filter], freq_max, freq_step, use_dB, unwrap_phase)
 
     // calculate transfer function for attitude controller with feedforward enabled (includes intermediate steps)
@@ -908,9 +908,9 @@ function calculate_predicted_TF(H_acft, sample_rate, window_size) {
     var tc_filter = []
     var tc_freq
     if (get_axis_prefix() == "YAW_") {
-        tc_freq = 1 / (get_form("PILOT_Y_RATE_TC") * 2 * Math.PI)
+        tc_freq = 1 / (get_form(get_vehicle_plt_prefix() + "Y_RATE_TC") * 2 * Math.PI)
     } else {
-        tc_freq = 1 / (get_form("ATC_INPUT_TC") * 2 * Math.PI)
+        tc_freq = 1 / (get_form(get_vehicle_att_prefix() + "INPUT_TC") * 2 * Math.PI)
     }
     tc_filter.push(new LPF_1P(PID_rate, tc_freq))
     const tc_H = evaluate_transfer_functions([tc_filter], freq_max, freq_step, use_dB, unwrap_phase)
@@ -1011,7 +1011,7 @@ let log
 var sid_axis
 var sid_sets = {}
 var use_ANG_message
-var vehicle_type
+var vehicle_type = "ArduCopter"
 function load_log(log_file) {
 
     log = new DataflashParser()
@@ -1307,10 +1307,8 @@ function update_PID_filters() {
     document.getElementById('YawNOTCH').style.display = 'none';
     document.getElementById('QYawNOTCH').style.display = 'none';
     if (vehicle_type == "ArduCopter") {
-        var param_prefix = "ATC_";
         var ele_prefix = "";
     } else if (vehicle_type == "ArduPlane") {
-        var param_prefix = "Q_A_";
         var ele_prefix = "Q";
     }
     for (let i = 1; i<9; i++) {    
@@ -1320,11 +1318,11 @@ function update_PID_filters() {
         document.getElementById(ele_prefix + 'RollPitchTC').style.display = 'block';
         document.getElementById(ele_prefix + 'RollPIDS').style.display = 'block';
         document.getElementById(ele_prefix + 'RollNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById(param_prefix + 'RAT_RLL_NTF').value;
+        const NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_RLL_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById(param_prefix + 'RAT_RLL_NEF').value;
+        const NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_RLL_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
@@ -1332,11 +1330,11 @@ function update_PID_filters() {
         document.getElementById(ele_prefix + 'RollPitchTC').style.display = 'block';
         document.getElementById(ele_prefix + 'PitchPIDS').style.display = 'block';
         document.getElementById(ele_prefix + 'PitchNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById(param_prefix + 'RAT_PIT_NTF').value;
+        const NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_PIT_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById(param_prefix + 'RAT_PIT_NEF').value;
+        const NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_PIT_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
@@ -1344,11 +1342,11 @@ function update_PID_filters() {
         document.getElementById(ele_prefix + 'YawTC').style.display = 'block';
         document.getElementById(ele_prefix + 'YawPIDS').style.display = 'block';
         document.getElementById(ele_prefix + 'YawNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById(param_prefix + 'RAT_YAW_NTF').value;
+        const NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_YAW_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById(param_prefix + 'RAT_YAW_NEF').value;
+        const NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_YAW_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
@@ -2286,4 +2284,22 @@ function set_sid_axis(axis) {
     }
     sid_axis = axis
     axis_changed()
+}
+
+function get_vehicle_att_prefix() {
+    if (vehicle_type == "ArduCopter") {
+        return "ATC_"
+    } else if (vehicle_type == "ArduPlane") {
+        return "Q_A_"
+    }
+    return ""
+}
+
+function get_vehicle_plt_prefix() {
+    if (vehicle_type == "ArduCopter") {
+        return "PILOT_"
+    } else if (vehicle_type == "ArduPlane") {
+        return "Q_PLT_"
+    }
+    return ""
 }

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1297,51 +1297,58 @@ function update_PID_filters() {
     document.getElementById('RollPIDS').style.display = 'none';
     document.getElementById('QRollPIDS').style.display = 'none';
     document.getElementById('PitchPIDS').style.display = 'none';
+    document.getElementById('QPitchPIDS').style.display = 'none';
     document.getElementById('YawPIDS').style.display = 'none';
+    document.getElementById('QYawPIDS').style.display = 'none';
     document.getElementById('RollNOTCH').style.display = 'none';
+    document.getElementById('QRollNOTCH').style.display = 'none';
     document.getElementById('PitchNOTCH').style.display = 'none';
+    document.getElementById('QPitchNOTCH').style.display = 'none';
     document.getElementById('YawNOTCH').style.display = 'none';
+    document.getElementById('QYawNOTCH').style.display = 'none';
+    if (vehicle_type == "ArduCopter") {
+        var param_prefix = "ATC_";
+        var ele_prefix = "";
+    } else if (vehicle_type == "ArduPlane") {
+        var param_prefix = "Q_A_";
+        var ele_prefix = "Q";
+    }
     for (let i = 1; i<9; i++) {    
         document.getElementById('FILT' + i).style.display = 'none';
     }
     if (document.getElementById('type_Roll').checked) {
-        document.getElementById('RollPitchTC').style.display = 'block';
-        if (vehicle_type == "ArduCopter") {
-            document.getElementById('RollPIDS').style.display = 'block';
-        } else if (vehicle_type == "ArduPlane") {
-            console.log("printing Q_A_ params")
-            document.getElementById('QRollPIDS').style.display = 'block';
-        }
-        document.getElementById('RollNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById('ATC_RAT_RLL_NTF').value;
+        document.getElementById(ele_prefix + 'RollPitchTC').style.display = 'block';
+        document.getElementById(ele_prefix + 'RollPIDS').style.display = 'block';
+        document.getElementById(ele_prefix + 'RollNOTCH').style.display = 'block';
+        const NTF_num = document.getElementById(param_prefix + 'RAT_RLL_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById('ATC_RAT_RLL_NEF').value;
+        const NEF_num = document.getElementById(param_prefix + 'RAT_RLL_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
     } else if (document.getElementById('type_Pitch').checked) {
-        document.getElementById('RollPitchTC').style.display = 'block';
-        document.getElementById('PitchPIDS').style.display = 'block';
-        document.getElementById('PitchNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById('ATC_RAT_PIT_NTF').value;
+        document.getElementById(ele_prefix + 'RollPitchTC').style.display = 'block';
+        document.getElementById(ele_prefix + 'PitchPIDS').style.display = 'block';
+        document.getElementById(ele_prefix + 'PitchNOTCH').style.display = 'block';
+        const NTF_num = document.getElementById(param_prefix + 'RAT_PIT_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById('ATC_RAT_PIT_NEF').value;
+        const NEF_num = document.getElementById(param_prefix + 'RAT_PIT_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }
     } else if (document.getElementById('type_Yaw').checked) {
-        document.getElementById('YawTC').style.display = 'block';
-        document.getElementById('YawPIDS').style.display = 'block';
-        document.getElementById('YawNOTCH').style.display = 'block';
-        const NTF_num = document.getElementById('ATC_RAT_YAW_NTF').value;
+        document.getElementById(ele_prefix + 'YawTC').style.display = 'block';
+        document.getElementById(ele_prefix + 'YawPIDS').style.display = 'block';
+        document.getElementById(ele_prefix + 'YawNOTCH').style.display = 'block';
+        const NTF_num = document.getElementById(param_prefix + 'RAT_YAW_NTF').value;
         if (NTF_num > 0) {
             document.getElementById('FILT' + NTF_num).style.display = 'block';
         }
-        const NEF_num = document.getElementById('ATC_RAT_YAW_NEF').value;
+        const NEF_num = document.getElementById(param_prefix + 'RAT_YAW_NEF').value;
         if (NEF_num > 0 && NEF_num != NTF_num) {
             document.getElementById('FILT' + NEF_num).style.display = 'block';
         }

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1766,50 +1766,50 @@ function save_parameters() {
         for (const v in inputs) {
             var name = "" + inputs[v].id;
             if (document.getElementById('type_Roll').checked) {
-                if (name.startsWith("ATC_INPUT_")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "INPUT_")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                if (name.startsWith("ATC_RAT_RLL")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "RAT_RLL")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                if (name.startsWith("ATC_ANG_RLL")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "ANG_RLL")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                NEF_num = document.getElementById('ATC_RAT_RLL_NEF').value
-                NTF_num = document.getElementById('ATC_RAT_RLL_NTF').value
+                NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_RLL_NEF').value
+                NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_RLL_NTF').value
             } else if (document.getElementById('type_Pitch').checked) {
-                if (name.startsWith("ATC_INPUT_")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "INPUT_")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                if (name.startsWith("ATC_RAT_PIT")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "RAT_PIT")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                if (name.startsWith("ATC_ANG_PIT")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "ANG_PIT")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                NEF_num = document.getElementById('ATC_RAT_PIT_NEF').value
-                NTF_num = document.getElementById('ATC_RAT_PIT_NTF').value
+                NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_PIT_NEF').value
+                NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_PIT_NTF').value
             } else if (document.getElementById('type_Yaw').checked) {
-                if (name.startsWith("PILOT_")) {
+                if (name.startsWith("PILOT_") || name.startsWith("Q_PLT_")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                    if (name.startsWith("ATC_RAT_YAW")) {
+                    if (name.startsWith(get_vehicle_att_prefix() + "RAT_YAW")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                if (name.startsWith("ATC_ANG_YAW")) {
+                if (name.startsWith(get_vehicle_att_prefix() + "ANG_YAW")) {
                     var value = inputs[v].value;
                     params += name + "," + param_to_string(value) + "\n";
                 }
-                NEF_num = document.getElementById('ATC_RAT_YAW_NEF').value
-                NTF_num = document.getElementById('ATC_RAT_YAW_NTF').value
+                NEF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_YAW_NEF').value
+                NTF_num = document.getElementById(get_vehicle_att_prefix() + 'RAT_YAW_NTF').value
             }
             if (NEF_num > 0) {
                 if (name.startsWith("FILT" + NEF_num + "_")) {
@@ -1847,7 +1847,7 @@ async function load_parameters(file) {
     var lines = text.split('\n');
     for (i in lines) {
         var line = lines[i];
-        line = line.replace("Q_A_RAT_","ATC_RAT_");
+//        line = line.replace("Q_A_RAT_","ATC_RAT_");
         v = line.split(/[\s,=\t]+/);
         if (v.length >= 2) {
             var vname = v[0];

--- a/AnalyticTune/AnalyticTune.js
+++ b/AnalyticTune/AnalyticTune.js
@@ -1167,7 +1167,12 @@ function load_log(log_file) {
         "PILOT_Y_RATE_TC",
         "ATC_ANG_RLL_P",
         "ATC_ANG_PIT_P",
-        "ATC_ANG_YAW_P"
+        "ATC_ANG_YAW_P",
+        "Q_A_INPUT_TC",
+        "Q_PLT_Y_RATE_TC",
+        "Q_A_ANG_RLL_P",
+        "Q_A_ANG_PIT_P",
+        "Q_A_ANG_YAW_P"
     ]
 
     for (const param of other_params) {

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -249,6 +249,35 @@
                                         <input id="ATC_RAT_RLL_FLTD" name="ATC_RAT_RLL_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
+                        <div id="QRollPIDS" style="display:none">
+                                <p>
+                                        <input id="Q_A_ANG_RLL_P" name="Q_A_ANG_RLL_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_FF" name="Q_A_RAT_RLL_FF" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_P" name="Q_A_RAT_RLL_P" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_I" name="Q_A_RAT_RLL_I" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_D" name="Q_A_RAT_RLL_D" type="number" step="0.0001" value="0.0117" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_D_FF" name="Q_A_RAT_RLL_D_FF" type="number" step="0.0001" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>       
+                                <p>
+                                        <input id="Q_A_RAT_RLL_FLTT" name="Q_A_RAT_RLL_FLTT" type="number" step="0.01" value="1.77" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_FLTE" name="Q_A_RAT_RLL_FLTE" type="number" step="0.01" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_FLTD" name="Q_A_RAT_RLL_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="PitchPIDS" style="display:none">
                                 <p>
                                         <input id="ATC_ANG_PIT_P" name="ATC_ANG_PIT_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -215,9 +215,19 @@
                                         <input id="ATC_INPUT_TC" name="ATC_INPUT_TC" type="number" step="0.01" value="0.15" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
+                        <div id="QRollPitchTC" style="display:none">
+                                <p>
+                                        <input id="Q_A_INPUT_TC" name="Q_A_INPUT_TC" type="number" step="0.01" value="0.15" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="YawTC" style="display:None">
                                 <p>
                                         <input id="PILOT_Y_RATE_TC" name="PILOT_Y_RATE_TC" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
+                        <div id="QYawTC" style="display:None">
+                                <p>
+                                        <input id="Q_PLT_Y_RATE_TC" name="Q_PLT_Y_RATE_TC" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
                         <div id="RollPIDS" style="display:block">
@@ -307,6 +317,35 @@
                                         <input id="ATC_RAT_PIT_FLTD" name="ATC_RAT_PIT_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
+                        <div id="QPitchPIDS" style="display:none">
+                                <p>
+                                        <input id="Q_A_ANG_PIT_P" name="Q_A_ANG_PIT_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_FF" name="Q_A_RAT_PIT_FF" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_P" name="Q_A_RAT_PIT_P" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_I" name="Q_A_RAT_PIT_I" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_D" name="Q_A_RAT_PIT_D" type="number" step="0.0001" value="0.0117" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_D_FF" name="Q_A_RAT_PIT_D_FF" type="number" step="0.0001" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>        
+                                <p>
+                                        <input id="Q_A_RAT_PIT_FLTT" name="Q_A_RAT_PIT_FLTT" type="number" step="0.01" value="1.77" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_FLTE" name="Q_A_RAT_PIT_FLTE" type="number" step="0.01" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_FLTD" name="Q_A_RAT_PIT_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="YawPIDS" style="display:none">
                                 <p>
                                         <input id="ATC_ANG_YAW_P" name="ATC_ANG_YAW_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>
@@ -335,6 +374,34 @@
                                 <p>
                                         <input id="ATC_RAT_YAW_FLTD" name="ATC_RAT_YAW_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
                                 </p>
+                        <div id="QYawPIDS" style="display:none">
+                                <p>
+                                        <input id="Q_A_ANG_YAW_P" name="Q_A_ANG_YAW_P" type="number" step="0.1" value="4.5" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_FF" name="Q_A_RAT_YAW_FF" type="number" step="0.01" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_P" name="Q_A_RAT_YAW_P" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_I" name="Q_A_RAT_YAW_I" type="number" step="0.01" value="0.288" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_D" name="Q_A_RAT_YAW_D" type="number" step="0.0001" value="0.0117" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_D_FF" name="Q_A_RAT_YAW_D_FF" type="number" step="0.0001" value="0.0" onchange = "calculate_freq_resp()"/>
+                                </p>        
+                                <p>
+                                        <input id="Q_A_RAT_YAW_FLTT" name="Q_A_RAT_YAW_FLTT" type="number" step="0.01" value="1.77" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_FLTE" name="Q_A_RAT_YAW_FLTE" type="number" step="0.01" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_FLTD" name="Q_A_RAT_YAW_FLTD" type="number" step="0.01" value="20" onchange = "calculate_freq_resp()"/>
+                                </p>
                         </div>
                 </fieldset>
         </td>
@@ -349,6 +416,14 @@
                                         <input id="ATC_RAT_RLL_NEF" name="ATC_RAT_RLL_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
+                        <div id="QRollNOTCH" style="display:none">
+                                <p>
+                                        <input id="Q_A_RAT_RLL_NTF" name="Q_A_RAT_RLL_NTF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_RLL_NEF" name="Q_A_RAT_RLL_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="PitchNOTCH" style="display:none">
                                 <p>
                                         <input id="ATC_RAT_PIT_NTF" name="ATC_RAT_PIT_NTF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
@@ -357,12 +432,28 @@
                                         <input id="ATC_RAT_PIT_NEF" name="ATC_RAT_PIT_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
+                        <div id="QPitchNOTCH" style="display:none">
+                                <p>
+                                        <input id="Q_A_RAT_PIT_NTF" name="Q_A_RAT_PIT_NTF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_PIT_NEF" name="Q_A_RAT_PIT_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
                         <div id="YawNOTCH" style="display:none">
                                 <p>
                                         <input id="ATC_RAT_YAW_NTF" name="ATC_RAT_YAW_NTF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
                                 </p>
                                 <p>
                                         <input id="ATC_RAT_YAW_NEF" name="ATC_RAT_YAW_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                        </div>
+                        <div id="QYawNOTCH" style="display:none">
+                                <p>
+                                        <input id="Q_A_RAT_YAW_NTF" name="Q_A_RAT_YAW_NTF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
+                                </p>
+                                <p>
+                                        <input id="Q_A_RAT_YAW_NEF" name="Q_A_RAT_YAW_NEF" type="number" step="1" value="0" onchange = "calculate_freq_resp()"/>
                                 </p>
                         </div>
                         <div id="FILT1" style="display:none">

--- a/AnalyticTune/index.html
+++ b/AnalyticTune/index.html
@@ -616,10 +616,10 @@
       calculate_freq_resp();
   }
 
-  let params = ["SCHED_LOOP_RATE", "PILOT_Y_RATE_TC"]
+  let params = ["SCHED_LOOP_RATE", "PILOT_Y_RATE_TC", "Q_PLT_Y_RATE_TC"]
   var inputs = document.getElementsByTagName("input");
   for (param of inputs) {
-      if (param.id.startsWith("INS_") || param.id.startsWith("ATC_") || param.id.startsWith("FILT")) {
+      if (param.id.startsWith("INS_") || param.id.startsWith("ATC_") || param.id.startsWith("Q_A_") || param.id.startsWith("FILT")) {
           params.push(param.id)
       }
   }

--- a/AnalyticTune/params.json
+++ b/AnalyticTune/params.json
@@ -1950,6 +1950,736 @@
       "__field_text": "\n    // @DisplayName: Harmonic Notch Filter base frequency\n    // @Description: Harmonic Notch Filter base center frequency in Hz. This is the center frequency for static notches, the center frequency for Throttle based notches at the reference thrust value, and the minimum limit of center frequency variation for all other notch types. This should always be set lower than half the backend gyro rate (which is typically 1Khz). \n    // @Range: 10 495\n    // @Units: Hz\n    // @User: Advanced"
     }
   },
+  "Q_A_": {
+    "Q_A_ACCEL_P_MAX": {
+      "Description": "Maximum acceleration in pitch axis",
+      "DisplayName": "Acceleration Max for Pitch",
+      "Increment": "1000",
+      "Range": {
+        "high": "180000",
+        "low": "0"
+      },
+      "Units": "cdeg/s/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "108000": "Medium",
+        "162000": "Fast",
+        "30000": "VerySlow",
+        "72000": "Slow"
+      },
+      "__field_text": "\n    // @DisplayName: Acceleration Max for Pitch\n    // @Description: Maximum acceleration in pitch axis\n    // @Units: cdeg/s/s\n    // @Range: 0 180000\n    // @Increment: 1000\n    // @Values: 0:Disabled, 30000:VerySlow, 72000:Slow, 108000:Medium, 162000:Fast\n    // @User: Advanced"
+    },
+    "Q_A_ACCEL_R_MAX": {
+      "Description": "Maximum acceleration in roll axis",
+      "DisplayName": "Acceleration Max for Roll",
+      "Increment": "1000",
+      "Range": {
+        "high": "180000",
+        "low": "0"
+      },
+      "Units": "cdeg/s/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "108000": "Medium",
+        "162000": "Fast",
+        "30000": "VerySlow",
+        "72000": "Slow"
+      },
+      "__field_text": "\n    // @DisplayName: Acceleration Max for Roll\n    // @Description: Maximum acceleration in roll axis\n    // @Units: cdeg/s/s\n    // @Range: 0 180000\n    // @Increment: 1000\n    // @Values: 0:Disabled, 30000:VerySlow, 72000:Slow, 108000:Medium, 162000:Fast\n    // @User: Advanced"
+    },
+    "Q_A_ACCEL_Y_MAX": {
+      "Description": "Maximum acceleration in yaw axis",
+      "DisplayName": "Acceleration Max for Yaw",
+      "Increment": "1000",
+      "Range": {
+        "high": "72000",
+        "low": "0"
+      },
+      "Units": "cdeg/s/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "18000": "Slow",
+        "36000": "Medium",
+        "54000": "Fast",
+        "9000": "VerySlow"
+      },
+      "__field_text": "\n    // @DisplayName: Acceleration Max for Yaw\n    // @Description: Maximum acceleration in yaw axis\n    // @Units: cdeg/s/s\n    // @Range: 0 72000\n    // @Values: 0:Disabled, 9000:VerySlow, 18000:Slow, 36000:Medium, 54000:Fast\n    // @Increment: 1000\n    // @User: Advanced"
+    },
+    "Q_A_ANGLE_BOOST": {
+      "Description": "Angle Boost increases output throttle as the vehicle leans to reduce loss of altitude",
+      "DisplayName": "Angle Boost",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "1": "Enabled"
+      },
+      "__field_text": "\n    // @DisplayName: Angle Boost\n    // @Description: Angle Boost increases output throttle as the vehicle leans to reduce loss of altitude\n    // @Values: 0:Disabled, 1:Enabled\n    // @User: Advanced"
+    },
+    "Q_A_ANG_LIM_TC": {
+      "Description": "Angle Limit (to maintain altitude) Time Constant",
+      "DisplayName": "Angle Limit (to maintain altitude) Time Constant",
+      "Range": {
+        "high": "10.0",
+        "low": "0.5"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Angle Limit (to maintain altitude) Time Constant\n    // @Description: Angle Limit (to maintain altitude) Time Constant\n    // @Range: 0.5 10.0\n    // @User: Advanced"
+    },
+    "Q_A_ANG_PIT_P": {
+      "Description": "Pitch axis angle controller P gain.  Converts the error between the desired pitch angle and actual angle to a desired pitch rate",
+      "DisplayName": "Pitch axis angle controller P gain",
+      "Range": {
+        "high": "12.000",
+        "low": "3.000"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis angle controller P gain\n    // @Description: Pitch axis angle controller P gain.  Converts the error between the desired pitch angle and actual angle to a desired pitch rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 12.000\n    // @User: Standard"
+    },
+    "Q_A_ANG_RLL_P": {
+      "Description": "Roll axis angle controller P gain.  Converts the error between the desired roll angle and actual angle to a desired roll rate",
+      "DisplayName": "Roll axis angle controller P gain",
+      "Range": {
+        "high": "12.000",
+        "low": "3.000"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis angle controller P gain\n    // @Description: Roll axis angle controller P gain.  Converts the error between the desired roll angle and actual angle to a desired roll rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 12.000\n    // @User: Standard"
+    },
+    "Q_A_ANG_YAW_P": {
+      "Description": "Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate",
+      "DisplayName": "Yaw axis angle controller P gain",
+      "Range": {
+        "high": "12.000",
+        "low": "3.000"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis angle controller P gain\n    // @Description: Yaw axis angle controller P gain.  Converts the error between the desired yaw angle and actual angle to a desired yaw rate\n    // @Range: 3.000 12.000\n    // @Range{Sub}: 0.0 6.000\n    // @User: Standard"
+    },
+    "Q_A_HOVR_ROL_TRM": {
+      "Description": "Trim the hover roll angle to counter tail rotor thrust in a hover",
+      "DisplayName": "Hover Roll Trim",
+      "Increment": "10",
+      "Range": {
+        "high": "1000",
+        "low": "0"
+      },
+      "Units": "cdeg",
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Hover Roll Trim\n    // @Description: Trim the hover roll angle to counter tail rotor thrust in a hover\n    // @Units: cdeg\n    // @Increment: 10\n    // @Range: 0 1000\n    // @User: Advanced"
+    },
+    "Q_A_INPUT_TC": {
+      "Description": "Attitude control input time constant.  Low numbers lead to sharper response, higher numbers to softer response",
+      "DisplayName": "Attitude control input time constant",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "Units": "s",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Attitude control input time constant\n    // @Description: Attitude control input time constant.  Low numbers lead to sharper response, higher numbers to softer response\n    // @Units: s\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @Values: 0.5:Very Soft, 0.2:Soft, 0.15:Medium, 0.1:Crisp, 0.05:Very Crisp\n    // @User: Standard"
+    },
+    "Q_A_PIRO_COMP": {
+      "Description": "Pirouette compensation enabled",
+      "DisplayName": "Piro Comp Enable",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "1": "Enabled"
+      },
+      "__field_text": "\n    // @DisplayName: Piro Comp Enable\n    // @Description: Pirouette compensation enabled\n    // @Values: 0:Disabled,1:Enabled\n    // @User: Advanced"
+    },
+    "Q_A_RATE_FF_ENAB": {
+      "Description": "Controls whether body-frame rate feedfoward is enabled or disabled",
+      "DisplayName": "Rate Feedforward Enable",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "1": "Enabled"
+      },
+      "__field_text": "\n    // @DisplayName: Rate Feedforward Enable\n    // @Description: Controls whether body-frame rate feedfoward is enabled or disabled\n    // @Values: 0:Disabled, 1:Enabled\n    // @User: Advanced"
+    },
+    "Q_A_RATE_P_MAX": {
+      "Description": "Maximum angular velocity in pitch axis",
+      "DisplayName": "Angular Velocity Max for Pitch",
+      "Increment": "1",
+      "Range": {
+        "high": "1080",
+        "low": "0"
+      },
+      "Units": "deg/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "180": "Medium",
+        "360": "Fast",
+        "60": "Slow"
+      },
+      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Pitch\n    // @Description: Maximum angular velocity in pitch axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+    },
+    "Q_A_RATE_R_MAX": {
+      "Description": "Maximum angular velocity in roll axis",
+      "DisplayName": "Angular Velocity Max for Roll",
+      "Increment": "1",
+      "Range": {
+        "high": "1080",
+        "low": "0"
+      },
+      "Units": "deg/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "180": "Medium",
+        "360": "Fast",
+        "60": "Slow"
+      },
+      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Roll\n    // @Description: Maximum angular velocity in roll axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+    },
+    "Q_A_RATE_Y_MAX": {
+      "Description": "Maximum angular velocity in yaw axis",
+      "DisplayName": "Angular Velocity Max for Yaw",
+      "Increment": "1",
+      "Range": {
+        "high": "1080",
+        "low": "0"
+      },
+      "Units": "deg/s",
+      "User": "Advanced",
+      "Values": {
+        "0": "Disabled",
+        "180": "Medium",
+        "360": "Fast",
+        "60": "Slow"
+      },
+      "__field_text": "\n    // @DisplayName: Angular Velocity Max for Yaw\n    // @Description: Maximum angular velocity in yaw axis\n    // @Units: deg/s\n    // @Range: 0 1080\n    // @Increment: 1\n    // @Values: 0:Disabled, 60:Slow, 180:Medium, 360:Fast\n    // @User: Advanced"
+    },
+    "Q_A_RAT_PIT_D": {
+      "Description": "Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate",
+      "DisplayName": "Pitch axis rate controller D gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.03",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller D gain\n    // @Description: Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_D_FF": {
+      "Description": "Pitch axis rate controller D feedforward gain.  ",
+      "DisplayName": "Pitch axis rate controller D feedforward gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.03",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller D FF gain\n    // @Description: Pitch axis rate controller D FF gain.\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_FF": {
+      "Description": "Pitch axis rate controller feed forward",
+      "DisplayName": "Pitch axis rate controller feed forward",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.5",
+        "low": "0.05"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller feed forward\n    // @Description: Pitch axis rate controller feed forward\n    // @Range: 0.05 0.5\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_FLTD": {
+      "Description": "Pitch axis rate controller derivative frequency in Hz",
+      "DisplayName": "Pitch axis rate controller derivative frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "0"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller derivative frequency in Hz\n    // @Description: Pitch axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_FLTE": {
+      "Description": "Pitch axis rate controller error frequency in Hz",
+      "DisplayName": "Pitch axis rate controller error frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller error frequency in Hz\n    // @Description: Pitch axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_FLTT": {
+      "Description": "Pitch axis rate controller target frequency in Hz",
+      "DisplayName": "Pitch axis rate controller target frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller target frequency in Hz\n    // @Description: Pitch axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_NTF": {
+      "Description": "Pitch Target Notch Filter Index",
+      "DisplayName": "Pitch Target Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Pitch Target Notch Filter Index\n    // @Description: Pitch Target Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_NEF": {
+      "Description": "Pitch Error Notch Filter Index",
+      "DisplayName": "Pitch Error Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Pitch Error Notch Filter Index\n    // @Description: Pitch Error Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_I": {
+      "Description": "Pitch axis rate controller I gain.  Corrects long-term difference in desired pitch rate vs actual pitch rate",
+      "DisplayName": "Pitch axis rate controller I gain",
+      "Increment": "0.01",
+      "Range": {
+        "high": "0.6",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I gain\n    // @Description: Pitch axis rate controller I gain.  Corrects long-term difference in desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.6\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_ILMI": {
+      "Description": "Point below which I-term will not leak down",
+      "DisplayName": "Pitch axis rate controller I-term leak minimum",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+    },
+    "Q_A_RAT_PIT_IMAX": {
+      "Description": "Pitch axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
+      "DisplayName": "Pitch axis rate controller I gain maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller I gain maximum\n    // @Description: Pitch axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_P": {
+      "Description": "Pitch axis rate controller P gain.  Corrects in proportion to the difference between the desired pitch rate vs actual pitch rate",
+      "DisplayName": "Pitch axis rate controller P gain",
+      "Increment": "0.005",
+      "Range": {
+        "high": "0.35",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Pitch axis rate controller P gain\n    // @Description: Pitch axis rate controller P gain.  Corrects in proportion to the difference between the desired pitch rate vs actual pitch rate\n    // @Range: 0.0 0.35\n    // @Increment: 0.005\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_PIT_SMAX": {
+      "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
+      "DisplayName": "Pitch slew rate limit",
+      "Increment": "0.5",
+      "Range": {
+        "high": "200",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Pitch slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_D": {
+      "Description": "Roll axis rate controller D gain.  Compensates for short-term change in desired roll rate vs actual roll rate",
+      "DisplayName": "Roll axis rate controller D gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.03",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller D gain\n    // @Description: Roll axis rate controller D gain.  Compensates for short-term change in desired roll rate vs actual roll rate\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_D_FF": {
+      "Description": "Roll axis rate controller D feedforward gain.  ",
+      "DisplayName": "Roll axis rate controller D feedforward gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.03",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller D FF gain\n    // @Description: Roll axis rate controller D FF gain.\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_FF": {
+      "Description": "Roll axis rate controller feed forward",
+      "DisplayName": "Roll axis rate controller feed forward",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.5",
+        "low": "0.05"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller feed forward\n    // @Description: Roll axis rate controller feed forward\n    // @Range: 0.05 0.5\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_FLTD": {
+      "Description": "Roll axis rate controller derivative frequency in Hz",
+      "DisplayName": "Roll axis rate controller derivative frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "0"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller derivative frequency in Hz\n    // @Description: Roll axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_FLTE": {
+      "Description": "Roll axis rate controller error frequency in Hz",
+      "DisplayName": "Roll axis rate controller error frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller error frequency in Hz\n    // @Description: Roll axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_FLTT": {
+      "Description": "Roll axis rate controller target frequency in Hz",
+      "DisplayName": "Roll axis rate controller target frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller target frequency in Hz\n    // @Description: Roll axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_NTF": {
+      "Description": "Roll Target Notch Filter Index",
+      "DisplayName": "Roll Target Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Roll Target Notch Filter Index\n    // @Description: Roll Target Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_NEF": {
+      "Description": "Roll Error Notch Filter Index",
+      "DisplayName": "Roll Error Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Roll Error Notch Filter Index\n    // @Description: Roll Error Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_I": {
+      "Description": "Roll axis rate controller I gain.  Corrects long-term difference in desired roll rate vs actual roll rate",
+      "DisplayName": "Roll axis rate controller I gain",
+      "Increment": "0.01",
+      "Range": {
+        "high": "0.6",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller I gain\n    // @Description: Roll axis rate controller I gain.  Corrects long-term difference in desired roll rate vs actual roll rate\n    // @Range: 0.0 0.6\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_ILMI": {
+      "Description": "Point below which I-term will not leak down",
+      "DisplayName": "Roll axis rate controller I-term leak minimum",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+    },
+    "Q_A_RAT_RLL_IMAX": {
+      "Description": "Roll axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
+      "DisplayName": "Roll axis rate controller I gain maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller I gain maximum\n    // @Description: Roll axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_P": {
+      "Description": "Roll axis rate controller P gain.  Corrects in proportion to the difference between the desired roll rate vs actual roll rate",
+      "DisplayName": "Roll axis rate controller P gain",
+      "Increment": "0.005",
+      "Range": {
+        "high": "0.35",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Roll axis rate controller P gain\n    // @Description: Roll axis rate controller P gain.  Corrects in proportion to the difference between the desired roll rate vs actual roll rate\n    // @Range: 0.0 0.35\n    // @Increment: 0.005\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_RLL_SMAX": {
+      "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
+      "DisplayName": "Roll slew rate limit",
+      "Increment": "0.5",
+      "Range": {
+        "high": "200",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Roll slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_D": {
+      "Description": "Yaw axis rate controller D gain.  Compensates for short-term change in desired yaw rate vs actual yaw rate",
+      "DisplayName": "Yaw axis rate controller D gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.02",
+        "low": "0.000"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller D gain\n    // @Description: Yaw axis rate controller D gain.  Compensates for short-term change in desired yaw rate vs actual yaw rate\n    // @Range: 0.000 0.02\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_FF": {
+      "Description": "Yaw axis rate controller feed forward",
+      "DisplayName": "Yaw axis rate controller feed forward",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.5",
+        "low": "0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller feed forward\n    // @Description: Yaw axis rate controller feed forward\n    // @Range: 0 0.5\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_D_FF": {
+      "Description": "Yaw axis rate controller D feedforward gain.  ",
+      "DisplayName": "Yaw axis rate controller D feedforward gain",
+      "Increment": "0.001",
+      "Range": {
+        "high": "0.03",
+        "low": "0.0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller D FF gain\n    // @Description: Yaw axis rate controller D FF gain.\n    // @Range: 0.0 0.03\n    // @Increment: 0.001\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_FLTD": {
+      "Description": "Yaw axis rate controller derivative frequency in Hz",
+      "DisplayName": "Yaw axis rate controller derivative frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "0"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller derivative frequency in Hz\n    // @Description: Yaw axis rate controller derivative frequency in Hz\n    // @Range: 0 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_FLTE": {
+      "Description": "Yaw axis rate controller error frequency in Hz",
+      "DisplayName": "Yaw axis rate controller error frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller error frequency in Hz\n    // @Description: Yaw axis rate controller error frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_FLTT": {
+      "Description": "Yaw axis rate controller target frequency in Hz",
+      "DisplayName": "Yaw axis rate controller target frequency in Hz",
+      "Increment": "1",
+      "Range": {
+        "high": "50",
+        "low": "5"
+      },
+      "Units": "Hz",
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller target frequency in Hz\n    // @Description: Yaw axis rate controller target frequency in Hz\n    // @Range: 5 50\n    // @Increment: 1\n    // @Units: Hz\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_NTF": {
+      "Description": "Yaw Target Notch Filter Index",
+      "DisplayName": "Yaw Target Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Yaw Target Notch Filter Index\n    // @Description: Yaw Target Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_NEF": {
+      "Description": "Yaw Error Notch Filter Index",
+      "DisplayName": "Yaw Error Notch Filter Index",
+      "Increment": "1",
+      "Range": {
+        "high": "8",
+        "low": "1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Yaw Error Notch Filter Index\n    // @Description: Yaw Error Notch Filter Index\n    // @Range: 1 8\n    // @Increment: 1\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_I": {
+      "Description": "Yaw axis rate controller I gain.  Corrects long-term difference in desired yaw rate vs actual yaw rate",
+      "DisplayName": "Yaw axis rate controller I gain",
+      "Increment": "0.01",
+      "Range": {
+        "high": "0.2",
+        "low": "0.01"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I gain\n    // @Description: Yaw axis rate controller I gain.  Corrects long-term difference in desired yaw rate vs actual yaw rate\n    // @Range: 0.01 0.2\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_ILMI": {
+      "Description": "Point below which I-term will not leak down",
+      "DisplayName": "Yaw axis rate controller I-term leak minimum",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I-term leak minimum\n    // @Description: Point below which I-term will not leak down\n    // @Range: 0 1\n    // @User: Advanced"
+    },
+    "Q_A_RAT_YAW_IMAX": {
+      "Description": "Yaw axis rate controller I gain maximum.  Constrains the maximum that the I term will output",
+      "DisplayName": "Yaw axis rate controller I gain maximum",
+      "Increment": "0.01",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller I gain maximum\n    // @Description: Yaw axis rate controller I gain maximum.  Constrains the maximum that the I term will output\n    // @Range: 0 1\n    // @Increment: 0.01\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_P": {
+      "Description": "Yaw axis rate controller P gain.  Corrects in proportion to the difference between the desired yaw rate vs actual yaw rate",
+      "DisplayName": "Yaw axis rate controller P gain",
+      "Increment": "0.005",
+      "Range": {
+        "high": "0.60",
+        "low": "0.180"
+      },
+      "User": "Standard",
+      "__field_text": "\n    // @DisplayName: Yaw axis rate controller P gain\n    // @Description: Yaw axis rate controller P gain.  Corrects in proportion to the difference between the desired yaw rate vs actual yaw rate\n    // @Range: 0.180 0.60\n    // @Increment: 0.005\n    // @User: Standard",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_RAT_YAW_SMAX": {
+      "Description": "Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.",
+      "DisplayName": "Yaw slew rate limit",
+      "Increment": "0.5",
+      "Range": {
+        "high": "200",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Yaw slew rate limit\n    // @Description: Sets an upper limit on the slew rate produced by the combined P and D gains. If the amplitude of the control action produced by the rate feedback exceeds this value, then the D+P gain is reduced to respect the limit. This limits the amplitude of high frequency oscillations caused by an excessive gain. The limit should be set to no more than 25% of the actuators maximum slew rate to allow for load effects. Note: The gain will not be reduced to less than 10% of the nominal value. A value of zero will disable this feature.\n    // @Range: 0 200\n    // @Increment: 0.5\n    // @User: Advanced",
+      "path": "AC_AttitudeControl_Heli"
+    },
+    "Q_A_SLEW_YAW": {
+      "Description": "Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes",
+      "DisplayName": "Yaw target slew rate",
+      "Increment": "100",
+      "Range": {
+        "high": "18000",
+        "low": "500"
+      },
+      "Units": "cdeg/s",
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Yaw target slew rate\n    // @Description: Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes\n    // @Units: cdeg/s\n    // @Range: 500 18000\n    // @Increment: 100\n    // @User: Advanced"
+    },
+    "Q_A_THR_G_BOOST": {
+      "Description": "Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.",
+      "DisplayName": "Throttle-gain boost",
+      "Range": {
+        "high": "1",
+        "low": "0"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Throttle-gain boost\n    // @Description: Throttle-gain boost ratio. A value of 0 means no boosting is applied, a value of 1 means full boosting is applied. Describes the ratio increase that is applied to angle P and PD on pitch and roll.\n    // @Range: 0 1\n    // @User: Advanced"
+    },
+    "Q_A_THR_MIX_MAN": {
+      "Description": "Throttle vs attitude control prioritisation used during manual flight (higher values mean we prioritise attitude control over throttle)",
+      "DisplayName": "Throttle Mix Manual",
+      "Range": {
+        "high": "0.9",
+        "low": "0.1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Throttle Mix Manual\n    // @Description: Throttle vs attitude control prioritisation used during manual flight (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.1 0.9\n    // @User: Advanced"
+    },
+    "Q_A_THR_MIX_MAX": {
+      "Description": "Throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)",
+      "DisplayName": "Throttle Mix Maximum",
+      "Range": {
+        "high": "0.9",
+        "low": "0.5"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Throttle Mix Maximum\n    // @Description: Throttle vs attitude control prioritisation used during active flight (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.5 0.9\n    // @User: Advanced"
+    },
+    "Q_A_THR_MIX_MIN": {
+      "Description": "Throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)",
+      "DisplayName": "Throttle Mix Minimum",
+      "Range": {
+        "high": "0.25",
+        "low": "0.1"
+      },
+      "User": "Advanced",
+      "__field_text": "\n    // @DisplayName: Throttle Mix Minimum\n    // @Description: Throttle vs attitude control prioritisation used when landing (higher values mean we prioritise attitude control over throttle)\n    // @Range: 0.1 0.25\n    // @User: Advanced"
+    }
+  },
     "json": {
     "version": 0
   }


### PR DESCRIPTION
This PR modifies the analytic webtool to enable quadplane users to load data and tune using this tool.  The main changes deal with managing the Q_ parameters.

Could use help making this code more efficient and viewable as I had to repeat the groups in the index file to allow the tool to be used for both multirotor and quadplane