### PR TITLE
Libraries: LogHelpers: Fix OEM FW identification

### DIFF
--- a/Libraries/LogHelpers.js
+++ b/Libraries/LogHelpers.js
@@ -38,20 +38,19 @@ function get_version_and_board(log) {
         if ("FV" in VER) {
             filter_version = VER.FV[0]
         }
+
+        if ((build_names[build_type] != null) && !fw_string.startsWith(build_names[build_type])) {
+            // If the log is from OEM-customized firmware with an
+            // AP_CUSTOM_FIRMWARE_STRING, append the base firmware info.
+            // This also means it will match how it appears in the MSGs,
+            // so os_string and fight_controller will not be returned undefined.
+            const { Maj = ['?'], Min = ['?'], Pat = ['?'] } = VER
+            fw_string += ` [${build_names[build_type]} V${Maj[0]}.${Min[0]}.${Pat[0]}]`
+        }
     }
 
     if ('MSG' in log.messageTypes) {
         const MSG = log.get("MSG")
-
-        if (build_names[build_type] && !fw_string.startsWith(build_names[build_type])) {
-            // If the log is from OEM-customized firmware with an
-            // AP_CUSTOM_FIRMWARE_STRING, append the base firmware info to match
-            // how it will appear in the MSGs. Otherwise, os_string and
-            // flight_controller will be returned undefined.
-            const { Maj = [0], Min = [0], Pat = [0] } = log.get("VER")
-            fw_string += ` [${build_names[build_type]} V${Maj[0]}.${Min[0]}.${Pat[0]}]`
-        }
-
         // Look for firmware string in MSGs, this marks the start of the log start msgs
         // The subsequent messages give more info, this is a bad way of doing it
         const len = MSG.Message.length


### PR DESCRIPTION
The function `get_version_and_board` returned `os_string` and `flight_controller` undefined for logs generated by boards running OEM-customized firmware. This caused issues such as Log Finder grouping all these logs under the "Unknown" category, even when they came from different boards.

Fixed by adjusting OEM-customized firmware strings to match the expected format. This solution has the advantage of including the name and version of the base firmware in the returned `fw_string`, which provides additional context downstream (e.g. in Log Finder).