### PR TITLE
Libraries: DecodeDevID: update baro types

### DIFF
--- a/Libraries/DecodeDevID.js
+++ b/Libraries/DecodeDevID.js
@@ -103,12 +103,13 @@ baro_types = {
     0x0F : "ICP101XX",
     0x10 : "ICP201XX",
     0x11 : "MS5607",
-    0x12 : "MS5837",
+    0x12 : "MS5837_30BA",
     0x13 : "MS5637",
     0x14 : "BMP390",
     0x15 : "BMP581",
     0x16 : "SPA06",
     0x17 : "AUAV",
+    0x18 : "MS5837_02BA",
 }
 
 airspeed_types = {


### PR DESCRIPTION
Updating to match adjusted baro types from ardupilot/ardupilot#29122 - per @IamPete1's [review comment](https://github.com/ArduPilot/ardupilot/pull/29122/files#r2161463563).

Changes:
- Add new `MS5837_02BA` barometer
- Distinguish original MS5837 as `_30BA` variant