### PR TITLE
HardwareReport: load file if present on page load

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -3114,10 +3114,11 @@ async function load_log(log_file) {
     console.log(`Load took: ${end - start} ms`)
 }
 
-async function load(e) {
+async function load() {
     reset()
 
-    const file = e.files[0]
+    const button = document.getElementById("fileItem")
+    const file = button.files[0]
     if (file == null) {
         return
     }
@@ -3648,11 +3649,15 @@ async function initial_load() {
         }
     }
 
-
-    fetch("board_types.txt")
-        .then((res) => {
-        return res.text();
-    }).then((data) => load_board_types(data));
+    return new Promise((resolve) => {
+        fetch("board_types.txt")
+            .then((res) => {
+            return res.text()
+        }).then((data) => {
+            load_board_types(data)
+            resolve()
+        });
+    })
 }
 
 function save_text(text, file_postfix) {

--- a/HardwareReport/index.html
+++ b/HardwareReport/index.html
@@ -35,8 +35,8 @@
 
 <h1><a href="" style="color: #000000; text-decoration:none;">ArduPilot Hardware Report</a></h1>
 
-<body onload="initial_load(); reset();">
-<input id="fileItem" type="file" accept=".param,.parm,.bin" onchange="load(this)">
+<body onload="initial_load().then(() => load());">
+<input id="fileItem" type="file" accept=".param,.parm,.bin" onchange="load()">
 
 <input id="OpenIn" type="button" value="Open In" disabled>
 


### PR DESCRIPTION
This means if you click away from the page and then go back if the file input remembers the file it will be loaded.

Currently this results in the odd situation where the file input has the file but the page is not loaded.

<img width="586" height="205" alt="image" src="https://github.com/user-attachments/assets/80b85bf1-6ce9-4992-849d-68a6ced7ad0a" />

This is annoying because if you then hit "Choose File" and select the same file again it does not fire the on-change event because there is no change, you have to reload the page and to clear the selection and then open the file again.

Now when you return to the page the log will be loaded.