### PR TITLE
TelemetryDashboard: fix editor rendering in firefox

### DIFF
--- a/TelemetryDashboard/index.html
+++ b/TelemetryDashboard/index.html
@@ -59,29 +59,23 @@
                 <span id="NameSpan" style="position:fixed; color:white; left:calc(2% + 10px); font-size:1.2em;">Widget Editor</span>
                 <svg id="Close" style="cursor:pointer; max-width:80%; max-height:80%;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path style="fill:white" d="M376.6 84.5c11.3-13.6 9.5-33.8-4.1-45.1s-33.8-9.5-45.1 4.1L192 206 56.6 43.5C45.3 29.9 25.1 28.1 11.5 39.4S-3.9 70.9 7.4 84.5L150.3 256 7.4 427.5c-11.3 13.6-9.5 33.8 4.1 45.1s33.8 9.5 45.1-4.1L192 306 327.4 468.5c11.3 13.6 31.5 15.4 45.1 4.1s15.4-31.5 4.1-45.1L233.7 256 376.6 84.5z"/></svg>
             </div>
-            <table style="width:100%; height:100%; flex:1; box-sizing:border-box;">
-                <tr>
-                    <td style="padding-right: 5px;">
-                        <div style="width:100%; height:100%; box-sizing:border-box; display:flex; flex-direction:column;">
-                            <div style="display:flex; justify-content: right; align-items: center; width:100%; height:2em; padding:2px; padding-right:10px; box-sizing:border-box; background-color:#c8c8c8; border-radius:4px;">
-                                <svg name="edit" style="cursor:pointer; max-width:80%; max-height:80%;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160L0 416c0 53 43 96 96 96l256 0c53 0 96-43 96-96l0-96c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 96c0 17.7-14.3 32-32 32L96 448c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 64z"/></svg>
-                                <svg name="lock" style="cursor:pointer; max-width:80%; max-height:80%;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M144 144l0 48 160 0 0-48c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192l0-48C80 64.5 144.5 0 224 0s144 64.5 144 144l0 48 16 0c35.3 0 64 28.7 64 64l0 192c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 256c0-35.3 28.7-64 64-64l16 0z"/></svg>
-                            </div>
-                            <div id="TestGrid" style="box-sizing:border-box; width:100%; height:100%; background-color:white; border-radius: 4px; flex:1"></div>
-                        </div>
-                    </td>
-                    <td style="padding-left: 5px; width:50%">
-                        <div style="width:100%; height:100%; box-sizing:border-box; display:flex; flex-direction:column;">
-                            <div style="display:flex; align-items: center; width:100%; height:2em; padding:2px; padding-right:10px; box-sizing:border-box; background-color:#c8c8c8; border-radius:4px;">
-                                <input name="script" type="button" value="Script" style="background-color: inherit; border:none; outline:none; height:100%; border-radius:4px;">
-                                <input name="form" type="button" value="Form" style="background-color: inherit; border:none; outline:none; height:100%; border-radius:4px;">
-                            </div>
-                            <div id="TextEditor" style="box-sizing:border-box; width:100%; height:100%; border-radius: 4px; padding-top:4px"></div>
-                            <div id="FormEditor" style="box-sizing:border-box; width:100%; height:100%; border-radius: 4px; padding:4px; background-color:white; display:none"></div>
-                        </div>
-                    </td>
-                </tr>
-            </table>
+            <div style="display:flex; width:100%; height:100%; flex:1; column-gap:10px;">
+                <div style="width:100%; height:100%; box-sizing:border-box; display:flex; flex-direction:column;">
+                    <div style="display:flex; justify-content: right; align-items: center; width:100%; height:2em; padding:2px; padding-right:10px; box-sizing:border-box; background-color:#c8c8c8; border-radius:4px;">
+                        <svg name="edit" style="cursor:pointer; max-width:80%; max-height:80%;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160L0 416c0 53 43 96 96 96l256 0c53 0 96-43 96-96l0-96c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 96c0 17.7-14.3 32-32 32L96 448c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 64z"/></svg>
+                        <svg name="lock" style="cursor:pointer; max-width:80%; max-height:80%;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M144 144l0 48 160 0 0-48c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192l0-48C80 64.5 144.5 0 224 0s144 64.5 144 144l0 48 16 0c35.3 0 64 28.7 64 64l0 192c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 256c0-35.3 28.7-64 64-64l16 0z"/></svg>
+                    </div>
+                    <div id="TestGrid" style="box-sizing:border-box; width:100%; height:100%; background-color:white; border-radius: 4px; flex:1"></div>
+                </div>
+                <div style="width:100%; height:100%; box-sizing:border-box; display:flex; flex-direction:column;">
+                    <div style="display:flex; align-items: center; width:100%; height:2em; padding:2px; padding-right:10px; box-sizing:border-box; background-color:#c8c8c8; border-radius:4px;">
+                        <input name="script" type="button" value="Script" style="background-color: inherit; border:none; outline:none; height:100%; border-radius:4px;">
+                        <input name="form" type="button" value="Form" style="background-color: inherit; border:none; outline:none; height:100%; border-radius:4px;">
+                    </div>
+                    <div id="TextEditor" style="box-sizing:border-box; width:100%; height:100%; border-radius: 4px; padding-top:4px"></div>
+                    <div id="FormEditor" style="box-sizing:border-box; width:100%; height:100%; border-radius: 4px; padding:4px; background-color:white; display:none"></div>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Firefox seems not to like the table method of splitting the editor view, the height property is lost. Currently you get:

<img width="2105" height="1068" alt="image" src="https://github.com/user-attachments/assets/7b004184-8c45-4669-ade9-51a95660f40b" />

With this fix you get the same as chrome:

<img width="2101" height="1074" alt="image" src="https://github.com/user-attachments/assets/c1647c53-47c7-400d-b29a-a42891a14934" />

There is still some speed issue on chrome, it seems to get very slow updates, firefox seems to be able to keep up better, I'm not sure why this is.
