### PR TITLE
Update arming check logic to use ARMING_SKIP instead of ARMING_CHECK in HardwareReport.js and LogFinder.js

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1694,7 +1694,7 @@ function load_params(log) {
     update_pos_plot()
 
     // Add warning if arming checks are disabled
-    if (("ARMING_CHECK" in params) && (params.ARMING_CHECK == 0)) {
+    if ((("ARMING_SKIPCHK" in params) && params.ARMING_SKIPCHK > 0) || (("ARMING_CHECK" in params) && params.ARMING_CHECK === 0)) {
         add_warning("exclamation-triangle-orange", document.createTextNode("Arming checks disabled"))
     }
 

--- a/LogFinder/LogFinder.js
+++ b/LogFinder/LogFinder.js
@@ -235,7 +235,7 @@ function setup_table(logs) {
         // Formatter to add custom buttons
         function check_warnings(cell, formatterParams, onRendered) {
             const log = cell.getRow().getData()
-            const arming_checks_disabled = ("ARMING_CHECK" in log.info.params) && (log.info.params["ARMING_CHECK"] == 0)
+            const arming_checks_disabled = (("ARMING_SKIPCHK" in log.info.params) && log.info.params.ARMING_SKIPCHK > 0) ||(("ARMING_CHECK" in log.info.params) && log.info.params.ARMING_CHECK === 0)
             if (!arming_checks_disabled && !log.info.watchdog && !log.info.crash_dump) {
                 // Nothing to warn about
                 return


### PR DESCRIPTION
This patch updates the arming check logic in two tools to support the new ArduPilot 4.7 parameter changes.

### Files updated
- `HardwareReport/HardwareReport.js`
- `LogFinder/LogFinder.js`

### What changed
ArduPilot 4.7 replaces the old `ARMING_CHECK` parameter with the new `ARMING_SKIP` bitmask.  
The existing tools were still checking for `ARMING_CHECK == 0` to detect disabled arming checks.

This PR updates both tools to use:

- `ARMING_SKIP > 0` → some checks skipped (show warning)
- Falls back cleanly for older logs if needed

### Why
The old logic no longer works with ArduPilot 4.7+ and can incorrectly show or hide warnings.  
These changes align the tools with the new parameter standard while keeping the original behavior.

No structural or UI changes were made — only minimal logic updates where the old parameter was used.