### PR TITLE
Add back navigation link to FilterReview page

### DIFF
--- a/FilterReview/index.html
+++ b/FilterReview/index.html
@@ -46,6 +46,7 @@
 </td></tr></table>
 
 <body>
+    <a href="../index.html" style="margin-left:30px; font-size:16px;">← Back to WebTools Home</a>
 
 <style>
     div.plotly-notifier {


### PR DESCRIPTION
This PR adds a small navigation link at the top of the FilterReview page to allow users to easily return to the main WebTools page.

Added:
`<a href="../index.html">← Back to WebTools Home</a>`

This improves navigation between subpages and the main WebTools page.

Related to issue #231.
