### PR TITLE
Libraries: DecodeDevID: add latest compass and imu devices

### DIFF
--- a/Libraries/DecodeDevID.js
+++ b/Libraries/DecodeDevID.js
@@ -44,7 +44,10 @@ compass_types = {
     0x13 : "MMC5883",
     0x14 : "AK09918",
     0x15 : "AK09915",
-    0x16 : "QMC5883P"
+    0x16 : "QMC5883P",
+    0x17 : "BMM350",
+    0x18 : "IIS2MDC",
+    0x19 : "LIS2MDL",
 }
 
 imu_types = {
@@ -83,6 +86,8 @@ imu_types = {
     0x3B : "ICM45686",
     0x3C : "SCHA63T",
     0x3D : "IIM42653",
+    0x3E : "LSM6DSV",
+    0x3F : "ASM330",
 }
 
 baro_types = {


### PR DESCRIPTION
I added ASM330 to imu types of DecodeDevID.
This addition of ASM330 is base on this PR https://github.com/ArduPilot/ardupilot/pull/31656.

I also added some missing devices from [Tools/scripts/decode_devid.py](https://github.com/ArduPilot/ardupilot/blob/master/Tools/scripts/decode_devid.py).