### PR TITLE
PIDReview: use log start and end time for end of group highlights

### DIFF
--- a/PIDReview/PIDReview.js
+++ b/PIDReview/PIDReview.js
@@ -821,8 +821,8 @@ function redraw() {
     // Rectangles to show param changes
     if (PID.params.sets.length > 1) {
         for (let i = 0; i < PID.params.sets.length; i++) {
-            const set_start = Math.max(time_range[0], PID.params.sets[i].start_time)
-            const set_end = Math.min(time_range[1], PID.params.sets[i].end_time)
+            const set_start = Math.max(PID_log_messages.start_time, PID.params.sets[i].start_time)
+            const set_end = Math.min(PID_log_messages.end_time, PID.params.sets[i].end_time)
 
             TimeInputs.layout.shapes[i].x0 = set_start
             TimeInputs.layout.shapes[i].x1 = set_end


### PR DESCRIPTION
Currently the first and last highlight sections start from the crop time, this means if you pan around there data without highlight.

<img width="502" height="969" alt="image" src="https://github.com/user-attachments/assets/10bcba9a-ff0e-4092-8ada-4d203db10198" />

Now the highlight extends to the start and the end of the log.

<img width="611" height="982" alt="image" src="https://github.com/user-attachments/assets/ad708dd0-4d3a-47fa-b68c-98ee7783779c" />
