### PR TITLE
HardwareReport: ARMING_SKIPCHK must be 0 for no warning

### DIFF
--- a/HardwareReport/HardwareReport.js
+++ b/HardwareReport/HardwareReport.js
@@ -1694,7 +1694,7 @@ function load_params(log) {
     update_pos_plot()
 
     // Add warning if arming checks are disabled
-    if ((("ARMING_SKIPCHK" in params) && params.ARMING_SKIPCHK > 0) || (("ARMING_CHECK" in params) && params.ARMING_CHECK === 0)) {
+    if ((("ARMING_SKIPCHK" in params) && params.ARMING_SKIPCHK != 0) || (("ARMING_CHECK" in params) && params.ARMING_CHECK === 0)) {
         add_warning("exclamation-triangle-orange", document.createTextNode("Arming checks disabled"))
     }
 


### PR DESCRIPTION
The param description suggests to use -1 to skip all which was missed.